### PR TITLE
Add GitHub Actions workflow for testing chezmoi apply

### DIFF
--- a/.github/workflows/test_chezmoi_apply.yml
+++ b/.github/workflows/test_chezmoi_apply.yml
@@ -1,0 +1,12 @@
+name: test chezmoi apply
+on:
+  - push
+jobs:
+  test:
+    name: test
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dotfiles
+        run: sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply -S .


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions workflow that runs on macOS to initialize and apply dotfiles with chezmoi on each push, ensuring configurations apply cleanly.
  * Includes a timeout to prevent long-running jobs and improve CI reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->