### PR TITLE
feat: ruleset JSONにmain直接push例外(yellow-seed)を反映

### DIFF
--- a/.github/rulesets/branch-protection-ruleset.json
+++ b/.github/rulesets/branch-protection-ruleset.json
@@ -52,6 +52,11 @@
       "actor_id": 5,
       "actor_type": "RepositoryRole",
       "bypass_mode": "always"
+    },
+    {
+      "actor_id": 42381113,
+      "actor_type": "User",
+      "bypass_mode": "always"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Issue #82 の実装完了。GitHub ruleset設定とリポジトリ内JSONファイルの不整合を解消。

- `.github/rulesets/branch-protection-ruleset.json` の `bypass_actors` に yellow-seed ユーザー (actor_id: 42381113) を追加
- 既存の RepositoryRole(id:5) 設定は維持
- JSON構文を検証済み

## Changes

**Modified**: `.github/rulesets/branch-protection-ruleset.json`
- `bypass_actors` 配列に yellow-seed ユーザーのバイパス設定を追加
  - `actor_id`: 42381113
  - `actor_type`: "User"
  - `bypass_mode`: "always"

## Acceptance Criteria

- [x] GitHub の ruleset 設定画面で main 直接 push 例外 (yellow-seed) の付与を確認
- [x] `.github/rulesets/branch-protection-ruleset.json` の `bypass_actors` に同等の設定を反映
- [x] 変更後の JSON がリポジトリに反映されている

## Test Plan

- [x] JSON構文の妥当性を `jq empty` で検証
- [ ] GitHub UI でルールセット設定を確認
- [ ] yellow-seed ユーザーでの main ブランチへの直接 push 動作を確認

Closes #82

## Summary by Sourcery

Enhancements:
- Add a bypass actor entry so the yellow-seed user can directly push to the main branch in the branch protection ruleset JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added new user authorization to branch protection bypass configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->