### PR TITLE
chore(ci): speed up macOS coverage run; limit bashcov and add DRY_RUN support (#93)

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -30,15 +30,22 @@ jobs:
         run: brew install bats-core
 
       - name: Run tests with coverage
+        timeout-minutes: 15
         run: |
           # Set environment variables for SimpleCov
           export CI=true
           export RUNNER_OS=macos
           export GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
 
-          # Run macOS-specific tests with coverage (bashcov is time-consuming)
-          # Only measure coverage for macOS-specific scripts
-          bashcov -- bats install/macos/
+          # Run a smaller macOS test subset with coverage (bashcov is time-consuming)
+          bashcov -- bats \
+            install/macos/01-brew.bats \
+            install/macos/02-brewfile.bats \
+            install/macos/03-profile.bats \
+            install/macos/setup.bats
+
+          # Run remaining macOS tests without coverage for speed
+          bats install/macos/brew-dump-explicit.bats
 
           # Run common and file tests without coverage for speed
           bats install/common/ tests/files/

--- a/install/macos/01-brew.bats
+++ b/install/macos/01-brew.bats
@@ -9,8 +9,9 @@
 }
 
 @test "brew installation script runs without errors" {
-  run bash install/macos/01-brew.sh
+  run env DRY_RUN=true bash install/macos/01-brew.sh
   [ "$status" -eq 0 ]
+  [[ "$output" =~ "\[DRY RUN\]" ]]
 }
 
 @test "brew command is available after installation" {

--- a/install/macos/01-brew.sh
+++ b/install/macos/01-brew.sh
@@ -6,12 +6,27 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
   set -x
 fi
 
+DRY_RUN="${DRY_RUN:-false}"
+
 # Homebrew関連の関数群
 function is_brew_exists() {
-  command -v brew &>/dev/null
+  if command -v brew &>/dev/null; then
+    return 0
+  fi
+
+  if [ -x "/opt/homebrew/bin/brew" ] || [ -x "/usr/local/bin/brew" ]; then
+    return 0
+  fi
+
+  return 1
 }
 
 function install_brew() {
+  if [ "${DRY_RUN}" = "true" ]; then
+    echo "[DRY RUN] Would install Homebrew"
+    return 0
+  fi
+
   if ! is_brew_exists; then
     echo "Installing Homebrew..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"


### PR DESCRIPTION
### Motivation
- The macOS `Run tests with coverage` step was excessively slow because `bashcov` runs coverage over the full macOS BATS suite which is time-consuming and sometimes hangs CI. 
- Avoid performing real Homebrew installs during fast coverage runs so tests remain deterministic and quick. 

### Description
- Limit `bashcov` to a small, fast subset of macOS tests by invoking it only for `install/macos/01-brew.bats`, `02-brewfile.bats`, `03-profile.bats`, and `setup.bats`, and run the remaining macOS tests without coverage to reduce runtime. 
- Add `timeout-minutes: 15` to the `Run tests with coverage` step to cap how long the coverage step can run. 
- Add `DRY_RUN` support and more robust brew detection to `install/macos/01-brew.sh` so the script can be exercised safely in CI without performing real installs. 
- Update `install/macos/01-brew.bats` to run the script in dry-run mode (`DRY_RUN=true`) and assert the expected dry-run output. 

### Testing
- No automated tests were executed as part of this change because it primarily modifies the CI workflow and test harness invocation. 
- BATS test updates were added (updated assertions and dry-run usage) and will be validated when the macOS CI workflow runs. 
- Related Issue: #93

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697427113fb4832db60f53bfafedc62c)

## Summary by Sourcery

Speed up macOS CI coverage runs and make the Homebrew install script safely testable in CI via dry-run mode.

New Features:
- Add DRY_RUN support to the macOS Homebrew install script to allow safe, no-op execution in CI.

Enhancements:
- Improve Homebrew detection on macOS by checking common install paths when the brew command is not on PATH.
- Limit macOS coverage runs to a small subset of BATS tests while running the remaining macOS tests without coverage to reduce CI runtime.
- Add an explicit timeout to the macOS coverage step to prevent excessively long or hanging CI runs.

CI:
- Adjust the macOS CI workflow to run only selected tests under bashcov and execute other test suites without coverage for faster feedback.
- Configure a 15-minute timeout on the macOS coverage job step.

Tests:
- Update the macOS Homebrew BATS test to exercise the script in dry-run mode and assert the expected dry-run output.