### PR TITLE
fix(ci): add DRY_RUN support to prevent timeout in macOS bats tests

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -30,11 +30,13 @@ jobs:
         run: brew install bats-core
 
       - name: Run tests with coverage
+        timeout-minutes: 15
         run: |
           # Set environment variables for SimpleCov
           export CI=true
           export RUNNER_OS=macos
           export GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
+          export DRY_RUN=true
 
           # Run macOS-specific tests with coverage (bashcov is time-consuming)
           # Only measure coverage for macOS-specific scripts

--- a/install/macos/brew.bats
+++ b/install/macos/brew.bats
@@ -9,8 +9,9 @@
 }
 
 @test "brew installation script runs without errors" {
-  run bash install/macos/brew.sh
+  run env DRY_RUN=true bash install/macos/brew.sh
   [ "$status" -eq 0 ]
+  [[ "$output" =~ "\[DRY RUN\]" ]]
 }
 
 @test "brew command is available after installation" {

--- a/install/macos/brew.sh
+++ b/install/macos/brew.sh
@@ -6,12 +6,27 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
   set -x
 fi
 
+export DRY_RUN="${DRY_RUN:-false}"
+
 # Homebrew関連の関数群
 function is_brew_exists() {
-  command -v brew &>/dev/null
+  if command -v brew &>/dev/null; then
+    return 0
+  fi
+
+  if [ -x "/opt/homebrew/bin/brew" ] || [ -x "/usr/local/bin/brew" ]; then
+    return 0
+  fi
+
+  return 1
 }
 
 function install_brew() {
+  if [ "${DRY_RUN}" = "true" ]; then
+    echo "[DRY RUN] Would install Homebrew"
+    return 0
+  fi
+
   if ! is_brew_exists; then
     echo "Installing Homebrew..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/install/macos/brewfile.bats
+++ b/install/macos/brewfile.bats
@@ -8,6 +8,12 @@
   [ -x "install/macos/brewfile.sh" ]
 }
 
+@test "brewfile script supports dry run" {
+  run env DRY_RUN=true bash install/macos/brewfile.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "\[DRY RUN\]" ]]
+}
+
 # Actual installation tests take time, so only basic operation checks are performed
 @test "brewfile script checks for brew command" {
   skip "Requires actual chezmoi setup"

--- a/install/macos/brewfile.sh
+++ b/install/macos/brewfile.sh
@@ -6,6 +6,8 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
   set -x
 fi
 
+export DRY_RUN="${DRY_RUN:-false}"
+
 # Brewfile関連の関数群
 function is_brew_exists() {
   command -v brew &>/dev/null
@@ -24,6 +26,11 @@ function install_brewfile() {
   if [ ! -f "$brewfile" ]; then
     echo "Error: Brewfile not found at ${brewfile}"
     exit 1
+  fi
+
+  if [ "${DRY_RUN}" = "true" ]; then
+    echo "[DRY RUN] Would install packages from ${brewfile}"
+    return 0
   fi
 
   echo "Installing packages from Brewfile..."


### PR DESCRIPTION
This commit fixes the timeout issue in macOS CI by:

1. Setting DRY_RUN=true in ci-macos.yml when running bashcov
2. Exporting DRY_RUN in brew.sh and brewfile.sh to propagate to child processes
3. Adding DRY_RUN support to both brew.sh and brewfile.sh
4. Adding DRY_RUN tests to brew.bats and brewfile.bats
5. Adding timeout-minutes: 15 to the test step

The timeout occurred because bashcov was executing scripts that
actually installed Homebrew, which takes a long time. With DRY_RUN=true,
scripts now skip actual installation and only validate their logic.

This fix addresses the same issue reported in PR #100.

## Summary by Sourcery

Add DRY_RUN support to macOS Homebrew install scripts and tests to avoid long-running real installations during CI, and configure the macOS CI workflow to run these tests in dry-run mode within a bounded timeout.

New Features:
- Introduce DRY_RUN mode to brew.sh to simulate Homebrew installation without performing real changes.
- Introduce DRY_RUN mode to brewfile.sh to simulate installing packages from a Brewfile.

Enhancements:
- Improve Homebrew detection in brew.sh by checking common installation paths when the brew command is not on PATH.

CI:
- Update macOS CI workflow to run bash coverage tests with DRY_RUN enabled and enforce a 15-minute timeout on the test step.

Tests:
- Add bats tests to verify DRY_RUN behavior for brew.sh and brewfile.sh and adjust existing brew installation test to run in dry-run mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dry-run mode for macOS installation scripts to preview changes without performing actual installations.

* **Tests**
  * Added test coverage for dry-run functionality.

* **Chores**
  * Updated CI workflow with improved timeout and environment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->