### PR TITLE
fix: E2E Setup Test の macOS 失敗を修正し Ubuntu を除外

### DIFF
--- a/.github/workflows/e2e-setup-test.yml
+++ b/.github/workflows/e2e-setup-test.yml
@@ -9,21 +9,15 @@ jobs:
   setup:
     permissions:
       contents: read
-    strategy:
-      fail-fast: false  # 1つのジョブが失敗しても他のジョブを継続
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    # Ubuntu is currently a stub implementation (see install/ubuntu/README.md)
+    # Only test macOS until Ubuntu setup is fully implemented
+    runs-on: macos-latest
     timeout-minutes: 30
-    
+
     steps:
       - name: Setup dotfiles
         run: |
-          if [ "${{ matrix.os }}" == "macos-latest" ]; then
-            bash -c "$(curl -fsLS https://raw.githubusercontent.com/yellow-seed/dotfiles/main/setup.sh)"
-          elif [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            bash -c "$(wget -qO - https://raw.githubusercontent.com/yellow-seed/dotfiles/main/setup.sh)"
-          fi
+          bash -c "$(curl -fsLS https://raw.githubusercontent.com/yellow-seed/dotfiles/main/setup.sh)"
       
       - name: Verify installation
         run: |

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
   set -x
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
 function run_script() {
   local script_path="$1"
@@ -43,6 +43,6 @@ function main() {
   echo "Dotfiles setup completed successfully!"
 }
 
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
   main
 fi


### PR DESCRIPTION
## Summary

- E2E Setup Test が macOS で失敗する問題を修正
- Ubuntu を E2E テスト対象から除外（Stub実装のため）

## Changes

### setup.sh
- `BASH_SOURCE[0]` が未定義時のフォールバックを追加
- `bash -c "$(curl ...)"` 実行時に `BASH_SOURCE[0]` が空になる問題を修正

### e2e-setup-test.yml
- Ubuntu を E2E テスト対象から除外
- マトリクス構成を削除し、macOS のみをテスト対象に

## Test plan

- [ ] E2E Setup Test ワークフローを手動実行して成功を確認
- [ ] `bash -c "$(curl -fsLS https://raw.githubusercontent.com/yellow-seed/dotfiles/main/setup.sh)"` がエラーなく動作することを確認

Closes #114

https://claude.ai/code/session_01HnhNp3FG1vkYGA4MLMTSbf

## Summary by Sourcery

Fix macOS E2E setup script execution and limit the E2E setup workflow to macOS only.

Bug Fixes:
- Prevent setup.sh from failing when BASH_SOURCE is undefined or empty during remote bash -c execution.

CI:
- Update E2E setup GitHub Actions workflow to run only on macOS and remove the Ubuntu matrix configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified continuous integration workflow to run on macOS platform exclusively.
  * Enhanced setup script with improved compatibility across different shell environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->