### PR TITLE
fix: checkout repo before running e2e setup

### DIFF
--- a/.github/workflows/e2e-setup-test.yml
+++ b/.github/workflows/e2e-setup-test.yml
@@ -15,9 +15,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup dotfiles
         run: |
-          bash -c "$(curl -fsLS https://raw.githubusercontent.com/yellow-seed/dotfiles/main/setup.sh)"
+          bash setup.sh
       
       - name: Verify installation
         run: |


### PR DESCRIPTION
### Motivation
- Related Issue: #6; the E2E workflow failed because it executed `setup.sh` via a remote `curl` invocation without checking out the repository, so the local `install/*` scripts referenced by `setup.sh` were not present and the script errored out.

### Description
- Add a `Checkout repository` step using `actions/checkout@v4` and change the Setup step to run the checked-out `setup.sh` with `bash setup.sh` instead of fetching and executing the script via `curl`.

### Testing
- No automated tests were run for this workflow-only change; the patch was committed and the workflow should be re-run in CI to verify the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d8616f0e0832d9db7a6e3d3fa21bd)

## Summary by Sourcery

CI:
- Update the E2E setup workflow to checkout the repository before running tests and invoke the local setup.sh script directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the e2e setup test workflow to use a local setup script instead of a remote invocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->