### PR TITLE
fix: drop deprecated homebrew/bundle tap and skip casks in CI (#7)

### DIFF
--- a/install/macos/02-brewfile.sh
+++ b/install/macos/02-brewfile.sh
@@ -38,8 +38,15 @@ function install_brewfile() {
     return 0
   fi
 
+  local bundle_args=("--file=$brewfile")
+
+  if [ -n "${CI:-}" ]; then
+    echo "CI environment detected; skipping cask installations."
+    bundle_args+=("--no-cask")
+  fi
+
   echo "Installing packages from Brewfile..."
-  brew bundle --file="$brewfile"
+  brew bundle "${bundle_args[@]}"
 }
 
 # メイン処理

--- a/install/macos/Brewfile
+++ b/install/macos/Brewfile
@@ -2,7 +2,6 @@
 tap "aws/tap"
 tap "dotenvx/brew"
 tap "go-swagger/go-swagger"
-tap "homebrew/bundle"
 
 # Formulae (explicitly installed)
 # Bourne-Again SHell, a UNIX command interpreter


### PR DESCRIPTION
### Motivation
- macOS CI runs were failing because `brew bundle` attempted to tap the deprecated `homebrew/bundle`, and cask installs in CI are unnecessary and often fail, so the Brewfile and installer should avoid both failure modes.

### Description
- Removed the deprecated `tap "homebrew/bundle"` entry from `install/macos/Brewfile`.
- Updated `install/macos/02-brewfile.sh` to build `bundle_args` and call `brew bundle "${bundle_args[@]}"` using `--file=<Brewfile>` and to append `--no-cask` when the `CI` environment variable is present to skip cask installs in CI.
- Preserved existing `DRY_RUN` behavior and existing checks for Homebrew and Brewfile presence.

### Testing
- No automated tests were executed in this rollout because `bats` was not run locally and CI has not yet been re-run.
- A prior macOS GitHub Actions run failed with a tap error from `homebrew/bundle` before this change, and removing the tap should prevent that failure; CI still needs a re-run to verify the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d8ceeba68832d89b03e9cdfc9e008)

## Summary by Sourcery

Update macOS Homebrew installation to avoid deprecated taps and make CI-safe Brewfile installs.

Bug Fixes:
- Remove use of the deprecated homebrew/bundle tap from the macOS Brewfile to prevent tap failures.
- Prevent cask installations from running in CI by adding conditional Brewfile bundle arguments based on the CI environment variable.