### PR TITLE
refactor(macos): inline Homebrew taps/formulae/casks and add idempotent installs (Refs #118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,13 +45,13 @@
 │   ├── macos/              # macOS専用
 │   │   ├── 01-brew.sh      # Homebrew自動インストール
 │   │   ├── 01-brew.bats    # Homebrewテスト
-│   │   ├── 02-brewfile.sh  # Brewfile自動適用
-│   │   ├── 02-brewfile.bats # Brewfileテスト
+│   │   ├── 02-brewfile.sh  # スクリプト内定義のパッケージをインストール
+│   │   ├── 02-brewfile.bats # パッケージインストールテスト
 │   │   ├── 03-profile.sh  # プロファイル固有パッケージインストール
 │   │   ├── 03-profile.bats # プロファイル固有パッケージテスト
 │   │   ├── setup.sh       # macOS用オーケストレーター
 │   │   ├── setup.bats     # macOS用オーケストレーターテスト
-│   │   ├── Brewfile        # Homebrewパッケージ定義
+│   │   ├── Brewfile        # brew-dump-explicit.sh の出力先
 │   │   ├── brew-dump-explicit.sh    # Brewfileダンプスクリプト
 │   │   ├── brew-dump-explicit.bats  # Brewfileダンプテスト
 │   │   ├── work/           # 仕事環境用Brewfile
@@ -112,7 +112,7 @@
 
 #### macOS専用 (macos/)
 - **01-brew.sh**: Homebrewの自動インストール
-- **02-brewfile.sh**: Brewfileからパッケージを一括インストール
+- **02-brewfile.sh**: スクリプト内で定義したタップ・パッケージを一括インストール
 - **03-profile.sh**: プロファイル固有パッケージのインストール
 - **setup.sh**: macOS用オーケストレーター
 - **brew-dump-explicit.sh**: 明示的にインストールされたパッケージをBrewfileにダンプ

--- a/install/macos/02-brewfile.bats
+++ b/install/macos/02-brewfile.bats
@@ -13,8 +13,22 @@
   [ "$status" -eq 0 ]
 }
 
+@test "brewfile installation script defines package arrays" {
+  run rg -n "^TAPS=\(" install/macos/02-brewfile.sh
+  [ "$status" -eq 0 ]
+  run rg -n "^FORMULAE=\(" install/macos/02-brewfile.sh
+  [ "$status" -eq 0 ]
+  run rg -n "^CASKS=\(" install/macos/02-brewfile.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "brewfile installation script does not use brew bundle" {
+  run rg -n "brew bundle" install/macos/02-brewfile.sh
+  [ "$status" -ne 0 ]
+}
+
 @test "brewfile script runs without errors in dry-run mode" {
   run env DRY_RUN=true bash install/macos/02-brewfile.sh
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "[DRY RUN]" ]] || [[ "$output" =~ "Installing packages" ]]
+  [[ "$output" =~ "[DRY RUN]" ]]
 }

--- a/install/macos/02-brewfile.sh
+++ b/install/macos/02-brewfile.sh
@@ -9,45 +9,125 @@ fi
 # ドライランモード設定
 DRY_RUN="${DRY_RUN:-false}"
 
-# Brewfile関連の関数群
+# パッケージ定義
+TAPS=(
+  "aws/tap"
+  "dotenvx/brew"
+  "go-swagger/go-swagger"
+  "homebrew/bundle"
+)
+
+FORMULAE=(
+  "bash"
+  "mise"
+  "python@3.12"
+  "tree"
+)
+
+CASKS=(
+  "1password"
+  "adobe-acrobat-reader"
+  "claude"
+  "claude-code"
+  "cursor"
+  "dbeaver-community"
+  "docker-desktop"
+  "ghostty"
+  "github"
+  "google-chrome"
+  "postman"
+  "raycast"
+  "shottr"
+  "visual-studio-code"
+  "warp"
+)
+
 function is_brew_exists() {
   command -v brew &>/dev/null
 }
 
-function install_brewfile() {
-  if ! is_brew_exists; then
-    if [ "${DRY_RUN}" = "true" ]; then
-      echo "[DRY RUN] Homebrew is not installed; skipping brew bundle."
-      return 0
-    fi
-    echo "Error: Homebrew is not installed"
-    exit 1
-  fi
-
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local brewfile="${script_dir}/Brewfile"
-
-  if [ ! -f "$brewfile" ]; then
-    echo "Error: Brewfile not found at ${brewfile}"
-    exit 1
-  fi
-
+function run_brew() {
   if [ "${DRY_RUN}" = "true" ]; then
-    echo "[DRY RUN] Would install packages from Brewfile: ${brewfile}"
+    echo "[DRY RUN] brew $*"
     return 0
   fi
 
-  echo "Installing packages from Brewfile..."
-  brew bundle --file="$brewfile"
+  brew "$@"
 }
 
-# メイン処理
+function ensure_brew() {
+  if is_brew_exists; then
+    return 0
+  fi
+
+  if [ "${DRY_RUN}" = "true" ]; then
+    echo "[DRY RUN] Homebrew is not installed; skipping package installation."
+    return 1
+  fi
+
+  echo "Error: Homebrew is not installed"
+  exit 1
+}
+
+function tap_exists() {
+  local tap="$1"
+  brew tap | grep -Fxq "$tap"
+}
+
+function formula_exists() {
+  local formula="$1"
+  brew list --formula "$formula" &>/dev/null
+}
+
+function cask_exists() {
+  local cask="$1"
+  brew list --cask "$cask" &>/dev/null
+}
+
+function install_taps() {
+  for tap in "${TAPS[@]}"; do
+    if tap_exists "$tap"; then
+      echo "Tap already added: $tap"
+      continue
+    fi
+    run_brew tap "$tap"
+  done
+}
+
+function install_formulae() {
+  for formula in "${FORMULAE[@]}"; do
+    if formula_exists "$formula"; then
+      echo "Formula already installed: $formula"
+      continue
+    fi
+    run_brew install "$formula"
+  done
+}
+
+function install_casks() {
+  for cask in "${CASKS[@]}"; do
+    if cask_exists "$cask"; then
+      echo "Cask already installed: $cask"
+      continue
+    fi
+    run_brew install --cask "$cask"
+  done
+}
+
+function install_packages() {
+  if ! ensure_brew; then
+    return 0
+  fi
+
+  install_taps
+  install_formulae
+  install_casks
+}
+
 function main() {
-  install_brewfile
+  install_packages
 }
 
-# スクリプトが直接実行された場合のみmainを実行
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main
 fi


### PR DESCRIPTION
### Motivation
- 対象Issue #118 の要件に従い、外部の `Brewfile` への依存をやめてスクリプト内でパッケージ管理を行い、セットアップの再現性と簡潔さを高めるためのリファクタリングを行った。

### Description
- `install/macos/02-brewfile.sh` を `TAPS` / `FORMULAE` / `CASKS` 配列でパッケージを定義し、`brew bundle` を使わず直接 `brew tap` / `brew install` / `brew install --cask` を実行するように変更した。 
- インストール前に存在チェックを行う `tap_exists` / `formula_exists` / `cask_exists` と、共通のラッパー `run_brew` / `ensure_brew` を追加して冪等性と `DRY_RUN` サポートを実装した。 
- テスト `install/macos/02-brewfile.bats` を更新して配列定義の存在と `brew bundle` を使っていないことを検証するように変更した。 
- ドキュメント `AGENTS.md` を更新して新しい動作（スクリプト内定義と `brew-dump-explicit.sh` の位置付け）を反映した。 

### Testing
- `bats install/macos/02-brewfile.bats` を実行しようとしたが、環境に `bats` がインストールされておらず自動テストは失敗した（`bats` not installed）。

Refs #118

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e0f3800f4832d8eb5c2a9eee713ac)

## Summary by Sourcery

Inline macOS Homebrew package definitions into the brew install script and make package installation idempotent without relying on Brewfile or brew bundle.

New Features:
- Define Homebrew taps, formulae, and casks as arrays within the macOS brew installation script to control installed packages directly.
- Add idempotent tap, formula, and cask installation logic with dry-run support for macOS setup.

Enhancements:
- Refine dry-run behavior to log simulated brew operations and skip installation when Homebrew is missing.
- Update macOS setup documentation to describe script-defined package installation and the role of Brewfile as a dump target rather than the primary source.

Tests:
- Extend macOS brewfile tests to assert the presence of inline package arrays, disallow usage of brew bundle, and tighten dry-run expectations.