### PR TITLE
refactor: manage Homebrew packages in 02-brewfile script (#118)

### DIFF
--- a/install/macos/02-brewfile.bats
+++ b/install/macos/02-brewfile.bats
@@ -1,20 +1,20 @@
 #!/usr/bin/env bats
 
-@test "brewfile installation script exists" {
+@test "brew installation script exists" {
   [ -f "install/macos/02-brewfile.sh" ]
 }
 
-@test "brewfile installation script is executable" {
+@test "brew installation script is executable" {
   [ -x "install/macos/02-brewfile.sh" ]
 }
 
-@test "brewfile installation script has proper error handling" {
+@test "brew installation script has proper error handling" {
   run grep "set -Eeuo pipefail" install/macos/02-brewfile.sh
   [ "$status" -eq 0 ]
 }
 
-@test "brewfile script runs without errors in dry-run mode" {
+@test "brew script runs without errors in dry-run mode" {
   run env DRY_RUN=true bash install/macos/02-brewfile.sh
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "[DRY RUN]" ]] || [[ "$output" =~ "Installing packages" ]]
+  [[ "$output" =~ "[DRY RUN]" ]] || [[ "$output" =~ "Installing Homebrew" ]]
 }

--- a/install/macos/02-brewfile.sh
+++ b/install/macos/02-brewfile.sh
@@ -9,42 +9,81 @@ fi
 # ドライランモード設定
 DRY_RUN="${DRY_RUN:-false}"
 
-# Brewfile関連の関数群
+# Homebrew関連の関数群
 function is_brew_exists() {
   command -v brew &>/dev/null
 }
 
-function install_brewfile() {
+function run_brew() {
+  if [ "${DRY_RUN}" = "true" ]; then
+    echo "[DRY RUN] brew $*"
+    return 0
+  fi
+
+  brew "$@"
+}
+
+function install_packages() {
   if ! is_brew_exists; then
     if [ "${DRY_RUN}" = "true" ]; then
-      echo "[DRY RUN] Homebrew is not installed; skipping brew bundle."
+      echo "[DRY RUN] Homebrew is not installed; skipping package installation."
       return 0
     fi
     echo "Error: Homebrew is not installed"
     exit 1
   fi
 
-  local script_dir
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local brewfile="${script_dir}/Brewfile"
+  local taps=(
+    "aws/tap"
+    "dotenvx/brew"
+    "go-swagger/go-swagger"
+    "homebrew/bundle"
+  )
 
-  if [ ! -f "$brewfile" ]; then
-    echo "Error: Brewfile not found at ${brewfile}"
-    exit 1
-  fi
+  local formulae=(
+    "bash"
+    "mise"
+    "python@3.12"
+    "tree"
+  )
 
-  if [ "${DRY_RUN}" = "true" ]; then
-    echo "[DRY RUN] Would install packages from Brewfile: ${brewfile}"
-    return 0
-  fi
+  local casks=(
+    "1password"
+    "adobe-acrobat-reader"
+    "claude"
+    "claude-code"
+    "cursor"
+    "dbeaver-community"
+    "docker-desktop"
+    "ghostty"
+    "github"
+    "google-chrome"
+    "postman"
+    "raycast"
+    "shottr"
+    "visual-studio-code"
+    "warp"
+  )
 
-  echo "Installing packages from Brewfile..."
-  brew bundle --file="$brewfile"
+  echo "Tapping Homebrew repositories..."
+  for tap in "${taps[@]}"; do
+    run_brew tap "$tap"
+  done
+
+  echo "Installing Homebrew formulae..."
+  for formula in "${formulae[@]}"; do
+    run_brew install "$formula"
+  done
+
+  echo "Installing Homebrew casks..."
+  for cask in "${casks[@]}"; do
+    run_brew install --cask "$cask"
+  done
 }
 
 # メイン処理
 function main() {
-  install_brewfile
+  install_packages
 }
 
 # スクリプトが直接実行された場合のみmainを実行


### PR DESCRIPTION
### Motivation
- Remove dependency on an external `Brewfile` and manage the canonical Homebrew taps/formulae/casks directly in the installation script to make setup more deterministic and easier to maintain (Issue #118). 
- Provide a dry-run aware installer so CI/tests can validate script execution without performing real installs.

### Description
- Inlined Homebrew `taps`, `formulae`, and `casks` as Bash arrays into `install/macos/02-brewfile.sh` and replaced `brew bundle` with explicit `brew tap`, `brew install`, and `brew install --cask` calls. 
- Added `run_brew` helper that emits DRY_RUN output when `DRY_RUN=true` and otherwise invokes `brew` with the given arguments. 
- Replaced the old `install_brewfile` flow with `install_packages` and updated `main()` to call it; preserved exit/error behavior when Homebrew is missing. 
- Updated the BATS test `install/macos/02-brewfile.bats` to reflect the renamed/changed script outputs and to validate dry-run behavior and basic script properties.

### Testing
- Ran the BATS test file with `bats install/macos/02-brewfile.bats`, but the run failed because `bats` is not installed in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69809fe07978832d8e2473695289ef1b)

## Summary by Sourcery

Manage Homebrew package installation directly in the macOS install script with dry-run support instead of relying on an external Brewfile.

New Features:
- Introduce inline configuration of Homebrew taps, formulae, and casks within the macOS installation script.
- Add a DRY_RUN-aware brew wrapper to simulate Homebrew commands without performing actual installations.

Enhancements:
- Replace Brewfile-based installation with explicit tap, formula, and cask installation flow while preserving Homebrew presence checks.
- Update macOS Homebrew installation tests to cover the new behavior and dry-run output expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated macOS installation process to use direct Homebrew commands instead of a configuration file-based approach.
  * Enhanced dry-run testing capabilities for the installation workflow.

* **Tests**
  * Updated test naming and validation for macOS installation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->