### PR TITLE
fix: remove deprecated homebrew/bundle tap from macOS setup

### DIFF
--- a/install/macos/02-brew-packages.sh
+++ b/install/macos/02-brew-packages.sh
@@ -37,7 +37,6 @@ function install_packages() {
     "aws/tap"
     "dotenvx/brew"
     "go-swagger/go-swagger"
-    "homebrew/bundle"
   )
 
   local formulae=(

--- a/install/macos/Brewfile
+++ b/install/macos/Brewfile
@@ -2,7 +2,6 @@
 tap "aws/tap"
 tap "dotenvx/brew"
 tap "go-swagger/go-swagger"
-tap "homebrew/bundle"
 
 # Formulae (explicitly installed)
 # Bourne-Again SHell, a UNIX command interpreter

--- a/install/macos/private/Brewfile
+++ b/install/macos/private/Brewfile
@@ -2,7 +2,6 @@
 tap "aws/tap"
 tap "dotenvx/brew"
 tap "go-swagger/go-swagger"
-tap "homebrew/bundle"
 tap "stuartleeks/tap"
 
 # Formulae (explicitly installed)


### PR DESCRIPTION
### Motivation
- E2E macOS setup was failing because `brew tap homebrew/bundle` is deprecated and caused the install step to exit under `set -Eeuo pipefail`.

### Description
- Remove `"homebrew/bundle"` from the `taps` array in `install/macos/02-brew-packages.sh` to avoid running `brew tap homebrew/bundle`.
- Remove `tap "homebrew/bundle"` from `install/macos/Brewfile` to keep Brewfiles consistent with Homebrew's integrated `brew bundle`.
- Remove `tap "homebrew/bundle"` from `install/macos/private/Brewfile` for the same reason.

### Testing
- Ran `DRY_RUN=true bash install/macos/02-brew-packages.sh` which completed successfully and printed the expected dry-run output.
- Verified removal with `rg -n "homebrew/bundle"` which returned no matches.
- Executed `git commit` which triggered pre-commit hooks (ShellCheck and shfmt); linters ran and the commit proceeded (linting passed).
- Attempted `bats install/macos/02-brew-packages.bats` but it failed because `bats` was not installed in the environment.

Close #123

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e91b89258832da5eef32a8d00ee62)

## Summary by Sourcery

Bug Fixes:
- Avoid macOS installation failures by no longer tapping the deprecated homebrew/bundle repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated Homebrew tap from macOS installation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->