### PR TITLE
fix: install bats in scripts/install-tools.sh

### DIFF
--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -288,6 +288,21 @@ install_prettier() {
   fi
 }
 
+install_bats() {
+  if command_exists bats; then
+    log "bats already installed: $(bats --version)"
+    return 0
+  fi
+
+  log "Installing bats..."
+  if install_packages bats; then
+    log "bats installed successfully via apt-get"
+    return 0
+  fi
+
+  fail "Failed to install bats"
+}
+
 install_helper_script() {
   local script_name="$1"
   local dest_name="$2"
@@ -323,6 +338,7 @@ main() {
   install_actionlint
   install_node
   install_prettier
+  install_bats
 
   install_helper_script "lint-shell" "lint-shell"
   install_helper_script "lint-docs" "lint-docs"


### PR DESCRIPTION
### Motivation
- Ensure the test runner BATS is installed by the repository tool installer so BATS-based tests can be executed automatically during setup.

### Description
- Added `install_bats` function to `scripts/install-tools.sh` which skips when `bats` is present and otherwise attempts installation via `apt-get`.
- Invoked `install_bats` from `main` so it runs with the other tool installers.

### Testing
- Ran `bash -n scripts/install-tools.sh` to validate script syntax and it succeeded. 
- Ran `shellcheck scripts/install-tools.sh` and fixed issues until pre-commit hooks passed. 
- Committed changes with pre-commit hooks (shellcheck/shfmt) passing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e92eaa79c832db639d6db7c13b119)

## Summary by Sourcery

Install the BATS test runner as part of the repository tool installation script so BATS-based tests are available by default.

New Features:
- Add bats installation support to scripts/install-tools.sh, including version-aware no-op when already installed.

Enhancements:
- Integrate bats installation into the main tool setup flow alongside existing linters and formatters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated BATS testing framework into the automated development environment setup process. The new installer checks for existing installations and automatically installs the tool if not present. Includes detailed logging for both successful and failed installation attempts, ensuring transparency in the tool initialization workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->