### PR TITLE
feat: enhance E2E setup workflow diagnostics

### DIFF
--- a/.github/workflows/e2e-setup-test.yml
+++ b/.github/workflows/e2e-setup-test.yml
@@ -18,12 +18,109 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Record environment (before setup)
+        run: |
+          mkdir -p /tmp/dotfiles-debug
+          {
+            echo "::group::Environment Info (before setup)"
+            echo "--- PATH ---"
+            echo "$PATH" | tr ':' '\n'
+            echo "--- Homebrew ---"
+            command -v brew && brew --version || echo "brew not found"
+            echo "--- Disk ---"
+            df -h /
+            echo "--- Runner Info ---"
+            sw_vers
+            uname -a
+            echo "::endgroup::"
+          } | tee /tmp/dotfiles-debug/environment-before.log
+
       - name: Setup dotfiles
         run: |
           bash setup.sh
+        env:
+          DOTFILES_DEBUG: "1"
+
+      - name: Record environment (after setup)
+        if: always()
+        run: |
+          mkdir -p /tmp/dotfiles-debug
+          {
+            echo "::group::Environment Info (after setup)"
+            echo "--- PATH ---"
+            echo "$PATH" | tr ':' '\n'
+            echo "--- Homebrew ---"
+            command -v brew && brew --version || echo "brew not found"
+            echo "--- Disk ---"
+            df -h /
+            echo "--- Runner Info ---"
+            sw_vers
+            uname -a
+            echo "::endgroup::"
+          } | tee /tmp/dotfiles-debug/environment-after.log
 
       - name: Verify installation
+        if: always()
         run: |
-          # 基本的な動作確認
+          mkdir -p /tmp/dotfiles-debug
+
+          {
+            echo "::group::PATH"
+            echo "$PATH" | tr ':' '\n'
+            echo "::endgroup::"
+
+            echo "::group::chezmoi verification"
+            echo "--- command -v chezmoi ---"
+            command -v chezmoi || echo "chezmoi not in PATH"
+            echo "--- find chezmoi ---"
+            find /usr/local/bin /opt/homebrew/bin "$HOME/bin" "$HOME/.local/bin" -name chezmoi 2>/dev/null || echo "chezmoi binary not found in common locations"
+            echo "--- chezmoi version ---"
+            chezmoi --version || echo "chezmoi --version failed"
+            echo "::endgroup::"
+
+            echo "::group::mise verification"
+            command -v mise && mise --version || echo "mise not found"
+            echo "::endgroup::"
+
+            echo "::group::brew verification"
+            command -v brew && brew --version || echo "brew not found"
+            brew list --formula 2>/dev/null | head -20 || true
+            echo "::endgroup::"
+          } | tee /tmp/dotfiles-debug/verify-installation.log
+
+          # 基本的な動作確認（失敗判定）
           command -v chezmoi
           chezmoi --version
+
+      - name: Collect debug info on failure
+        if: failure()
+        run: |
+          mkdir -p /tmp/dotfiles-debug
+          {
+            echo "::group::Full PATH"
+            echo "$PATH" | tr ':' '\n'
+            echo "::endgroup::"
+
+            echo "::group::Home directory"
+            ls -la "$HOME/" || true
+            ls -la "$HOME/.local/bin/" 2>/dev/null || echo "$HOME/.local/bin does not exist"
+            echo "::endgroup::"
+
+            echo "::group::Chezmoi state"
+            ls -la "$HOME/.local/share/chezmoi/" 2>/dev/null || echo "chezmoi source dir not found"
+            cat "$HOME/.config/chezmoi/chezmoi.toml" 2>/dev/null || echo "chezmoi config not found"
+            echo "::endgroup::"
+
+            echo "::group::Homebrew state"
+            brew config 2>/dev/null || echo "brew config failed"
+            brew doctor 2>/dev/null || echo "brew doctor failed"
+            echo "::endgroup::"
+          } | tee /tmp/dotfiles-debug/debug-on-failure.log
+
+      - name: Upload debug logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-logs
+          path: /tmp/dotfiles-debug/
+          retention-days: 7


### PR DESCRIPTION
### Motivation
- The E2E setup workflow provided insufficient runtime and post-failure diagnostics, making it hard to determine why `Verify installation` or long-running steps fail. 
- Persisting environment snapshots and targeted failure artifacts will speed up debugging and reduce noisy reruns.

### Description
- Add a `Record environment (before setup)` step that captures `PATH`, `brew` version, disk info and runner info to `/tmp/dotfiles-debug/environment-before.log` before running `setup.sh`.
- Enable `DOTFILES_DEBUG=1` for the `Setup dotfiles` step so script-level traces are emitted during `setup.sh` execution.
- Add a `Record environment (after setup)` step to capture the post-setup environment and save it to `/tmp/dotfiles-debug/environment-after.log`.
- Expand `Verify installation` to produce grouped diagnostics for `PATH`, `chezmoi`, `mise`, and `brew` into `/tmp/dotfiles-debug/verify-installation.log`, keep the final `chezmoi` checks as the pass/fail gate, and add a failure-only `Collect debug info on failure` step plus an `Upload debug logs` artifact action to preserve logs for investigation.

### Testing
- Ran `npm ci` successfully to install dev dependencies used by pre-commit hooks.
- Pre-commit checks including `prettier` and `actionlint` ran and passed during commit.
- Executed `scripts/install-tools.sh` to install required linting tools (succeeded) so workflow checks are satisfied.
- Commit created and PR description includes the linked issue reference to close the issue: Close #131

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eea93d954832da7f16fa6cb19f8a8)

## Summary by Sourcery

Improve E2E setup workflow diagnostics and failure observability for dotfiles installation.

New Features:
- Capture pre-setup environment details into a log file before running the dotfiles setup script.
- Capture post-setup environment details into a log file after running the dotfiles setup script.
- Persist grouped verification diagnostics for PATH, chezmoi, mise, and Homebrew into a dedicated log file.
- Upload collected debug logs as an artifact when the workflow fails for later analysis.

Enhancements:
- Enable debug mode for the dotfiles setup script via an environment variable to emit more detailed traces.
- Ensure verification and diagnostic steps always run while keeping chezmoi checks as the explicit pass/fail gate.

CI:
- Enhance the E2E setup CI workflow with richer logging, failure-only debug collection, and artifact uploads for troubleshooting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with improved debugging and diagnostic logging for setup verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->