### PR TITLE
fix: make chezmoi install to ~/.local/bin, avoid PATH duplication, and keep DRY_RUN side-effect free

### DIFF
--- a/install/common/chezmoi.bats
+++ b/install/common/chezmoi.bats
@@ -25,7 +25,6 @@ teardown() {
 @test "setup_chezmoi_bin_dir creates bin directory and prepends PATH once" {
   export HOME="${TEST_TEMP_HOME}"
   export CHEZMOI_BIN_DIR="${HOME}/.local/bin"
-  export PATH="/usr/bin:/bin"
 
   source install/common/chezmoi.sh
 

--- a/install/common/chezmoi.bats
+++ b/install/common/chezmoi.bats
@@ -13,9 +13,32 @@
   [ "$status" -eq 0 ]
 }
 
-@test "chezmoi installation script runs in dry-run mode" {
-  run env DRY_RUN=true GITHUB_USERNAME="test-user" bash install/common/chezmoi.sh
+@test "setup_chezmoi_bin_dir creates bin directory and prepends PATH once" {
+  temp_home="$(mktemp -d)"
+  export HOME="${temp_home}"
+  export CHEZMOI_BIN_DIR="${HOME}/.local/bin"
+  export PATH="/usr/bin:/bin"
+
+  source install/common/chezmoi.sh
+
+  setup_chezmoi_bin_dir
+  [ -d "${CHEZMOI_BIN_DIR}" ]
+  [ "${PATH}" = "${CHEZMOI_BIN_DIR}:/usr/bin:/bin" ]
+
+  setup_chezmoi_bin_dir
+  [ "${PATH}" = "${CHEZMOI_BIN_DIR}:/usr/bin:/bin" ]
+
+  rm -rf "${temp_home}"
+}
+
+@test "chezmoi installation script runs in dry-run mode without creating bin directory" {
+  temp_home="$(mktemp -d)"
+
+  run env DRY_RUN=true HOME="${temp_home}" GITHUB_USERNAME="test-user" bash install/common/chezmoi.sh
   [ "$status" -eq 0 ]
   [[ "$output" =~ "\\[DRY RUN\\]" ]]
   [[ "$output" =~ "test-user" ]]
+  [ ! -d "${temp_home}/.local/bin" ]
+
+  rm -rf "${temp_home}"
 }

--- a/install/common/chezmoi.sh
+++ b/install/common/chezmoi.sh
@@ -10,9 +10,16 @@ declare -r CHEZMOI_BIN_DIR="${CHEZMOI_BIN_DIR:-${HOME}/.local/bin}"
 DRY_RUN="${DRY_RUN:-false}"
 
 function setup_chezmoi_bin_dir() {
-  mkdir -p "${CHEZMOI_BIN_DIR}"
-  if [[ ":${PATH}:" != *":${CHEZMOI_BIN_DIR}:"* ]]; then
-    export PATH="${CHEZMOI_BIN_DIR}:${PATH}"
+  if ! /bin/mkdir -p "${CHEZMOI_BIN_DIR}"; then
+    echo "Error: Failed to create CHEZMOI_BIN_DIR: ${CHEZMOI_BIN_DIR}" >&2
+    return 1
+  fi
+
+  local current_path
+  current_path="${PATH:-}"
+
+  if [[ ":${current_path}:" != *":${CHEZMOI_BIN_DIR}:"* ]]; then
+    export PATH="${CHEZMOI_BIN_DIR}${current_path:+:${current_path}}"
   fi
 }
 

--- a/install/common/chezmoi.sh
+++ b/install/common/chezmoi.sh
@@ -6,7 +6,15 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
 fi
 
 declare -r GITHUB_USERNAME="${GITHUB_USERNAME:-yellow-seed}"
+declare -r CHEZMOI_BIN_DIR="${CHEZMOI_BIN_DIR:-${HOME}/.local/bin}"
 DRY_RUN="${DRY_RUN:-false}"
+
+function setup_chezmoi_bin_dir() {
+  mkdir -p "${CHEZMOI_BIN_DIR}"
+  if [[ ":${PATH}:" != *":${CHEZMOI_BIN_DIR}:"* ]]; then
+    export PATH="${CHEZMOI_BIN_DIR}:${PATH}"
+  fi
+}
 
 function run_chezmoi() {
   if [ "${DRY_RUN}" = "true" ]; then
@@ -14,12 +22,14 @@ function run_chezmoi() {
     return 0
   fi
 
+  setup_chezmoi_bin_dir
+
   if command -v curl &>/dev/null; then
     echo "Using curl to download chezmoi installer..."
-    sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply "${GITHUB_USERNAME}"
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "${CHEZMOI_BIN_DIR}" init --apply "${GITHUB_USERNAME}"
   elif command -v wget &>/dev/null; then
     echo "Using wget to download chezmoi installer..."
-    sh -c "$(wget -qO- get.chezmoi.io)" -- init --apply "${GITHUB_USERNAME}"
+    sh -c "$(wget -qO- get.chezmoi.io)" -- -b "${CHEZMOI_BIN_DIR}" init --apply "${GITHUB_USERNAME}"
   else
     echo "Error: Neither curl nor wget is available. Please install curl or wget to proceed." >&2
     echo "On Debian/Ubuntu: sudo apt-get install curl" >&2


### PR DESCRIPTION
### Motivation
- Ensure the chezmoi installer places the binary in a user-local bin (`${HOME}/.local/bin`) so the tool is available without requiring system-wide installs.
- Address reviewer feedback to avoid mutating the environment during `DRY_RUN` and to prevent repeated PATH prepends that can bloat `PATH`.
- Replace brittle source-string tests with behavioral tests that validate the actual runtime effects of the script.

### Description
- Related issue: Close #134
- Add `CHEZMOI_BIN_DIR` default (`${CHEZMOI_BIN_DIR:-${HOME}/.local/bin}`) in `install/common/chezmoi.sh` so the location is configurable.
- Add `setup_chezmoi_bin_dir()` which `mkdir -p` the directory and only prepends it to `PATH` when not already present, preventing duplicate entries.
- Move the bin-dir setup invocation to after the `DRY_RUN` early return so `DRY_RUN=true` produces no filesystem side effects.
- Ensure both `curl` and `wget` installer flows pass `-b "${CHEZMOI_BIN_DIR}"` to the chezmoi installer so the binary is installed into the local bin.
- Replace grep-only checks with functional BATS tests in `install/common/chezmoi.bats` that verify directory creation, idempotent PATH prepending, and that dry-run does not create the directory.

### Testing
- `bash -n install/common/chezmoi.sh` (syntax check) — succeeded.
- Manual dry-run check: `DRY_RUN=true HOME=<tmp> GITHUB_USERNAME=test-user bash install/common/chezmoi.sh` confirmed the dry-run output and that `<tmp>/.local/bin` was not created — succeeded.
- Functional setup check: sourced the script in a temp `HOME`, ran `setup_chezmoi_bin_dir` twice and asserted the directory exists and `PATH` was only prepended once — succeeded.
- Pre-commit linting (`shellcheck` and `shfmt`) ran via project hooks and passed in this environment.
- `bats install/common/chezmoi.bats` could not be executed here because `bats` was not installed in the environment; the updated BATS tests are included and should run in CI or any developer environment with `bats` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fd3658250832db79303b9517739e7)

## Summary by Sourcery

Install chezmoi into a configurable user-local bin directory while keeping dry runs side-effect free and ensuring PATH is updated idempotently.

New Features:
- Add configurable CHEZMOI_BIN_DIR defaulting to ${HOME}/.local/bin for chezmoi installations.

Bug Fixes:
- Prevent DRY_RUN executions of the chezmoi installer from creating the bin directory or mutating PATH.
- Avoid duplicate PATH entries by only prepending CHEZMOI_BIN_DIR when it is not already present.

Enhancements:
- Ensure curl and wget installer flows install chezmoi into the configured CHEZMOI_BIN_DIR.
- Add functional tests for bin directory creation, idempotent PATH prepending, and dry-run behavior in the chezmoi installer script.

Tests:
- Replace previous grep-based tests with BATS tests that validate chezmoi installer runtime behavior, including bin directory handling and dry-run semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now ensures a user-local bin directory exists and is added to PATH before installing; installer supports targeting that directory and preserves dry-run behavior.

* **Tests**
  * Added multiple installation tests covering bin-directory creation, PATH handling (including unset PATH), dry-run output/assertions, and setup/teardown of a temporary HOME environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->