### PR TITLE
fix(chezmoi): make bin-dir setup robust and update BATS tests

### DIFF
--- a/install/common/chezmoi.bats
+++ b/install/common/chezmoi.bats
@@ -46,7 +46,7 @@ teardown() {
 @test "chezmoi installation script runs in dry-run mode without creating bin dir" {
   run env DRY_RUN=true HOME="${TEMP_HOME}" GITHUB_USERNAME="test-user" bash install/common/chezmoi.sh
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "\\[DRY RUN\\]" ]]
+  [[ "$output" == *"[DRY RUN]"* ]]
   [[ "$output" =~ "test-user" ]]
   [ ! -d "${TEMP_HOME}/.local/bin" ]
 }

--- a/install/common/chezmoi.bats
+++ b/install/common/chezmoi.bats
@@ -1,5 +1,14 @@
 #!/usr/bin/env bats
 
+setup() {
+  export TEMP_HOME
+  TEMP_HOME="$(mktemp -d)"
+}
+
+teardown() {
+  [ -d "${TEMP_HOME}" ] && rm -rf "${TEMP_HOME}"
+}
+
 @test "chezmoi installation script exists" {
   [ -f "install/common/chezmoi.sh" ]
 }
@@ -13,19 +22,31 @@
   [ "$status" -eq 0 ]
 }
 
-@test "chezmoi installation script sets local bin directory" {
-  run grep 'CHEZMOI_BIN_DIR="${HOME}/.local/bin"' install/common/chezmoi.sh
+@test "setup_chezmoi_bin_dir creates bin dir and prepends PATH only once" {
+  run env HOME="${TEMP_HOME}" PATH="/usr/bin" bash -c '
+    source install/common/chezmoi.sh
+    setup_chezmoi_bin_dir
+    setup_chezmoi_bin_dir
+    [ -d "${CHEZMOI_BIN_DIR}" ]
+    [ "${PATH}" = "${CHEZMOI_BIN_DIR}:/usr/bin" ]
+  '
   [ "$status" -eq 0 ]
 }
 
-@test "chezmoi installation script installs binary to local bin" {
-  run grep -- '-b "${CHEZMOI_BIN_DIR}" init --apply' install/common/chezmoi.sh
+@test "setup_chezmoi_bin_dir handles unset PATH" {
+  run env -u PATH HOME="${TEMP_HOME}" bash -c '
+    source install/common/chezmoi.sh
+    setup_chezmoi_bin_dir
+    [ -d "${CHEZMOI_BIN_DIR}" ]
+    [[ "${PATH}" == "${CHEZMOI_BIN_DIR}:"* ]]
+  '
   [ "$status" -eq 0 ]
 }
 
-@test "chezmoi installation script runs in dry-run mode" {
-  run env DRY_RUN=true GITHUB_USERNAME="test-user" bash install/common/chezmoi.sh
+@test "chezmoi installation script runs in dry-run mode without creating bin dir" {
+  run env DRY_RUN=true HOME="${TEMP_HOME}" GITHUB_USERNAME="test-user" bash install/common/chezmoi.sh
   [ "$status" -eq 0 ]
   [[ "$output" =~ "\\[DRY RUN\\]" ]]
   [[ "$output" =~ "test-user" ]]
+  [ ! -d "${TEMP_HOME}/.local/bin" ]
 }

--- a/install/common/chezmoi.sh
+++ b/install/common/chezmoi.sh
@@ -7,20 +7,26 @@ fi
 
 declare -r GITHUB_USERNAME="${GITHUB_USERNAME:-yellow-seed}"
 DRY_RUN="${DRY_RUN:-false}"
-CHEZMOI_BIN_DIR="${HOME}/.local/bin"
+declare -r CHEZMOI_BIN_DIR="${CHEZMOI_BIN_DIR:-${HOME}/.local/bin}"
 
 function setup_chezmoi_bin_dir() {
-  mkdir -p "${CHEZMOI_BIN_DIR}"
-  export PATH="${CHEZMOI_BIN_DIR}:${PATH}"
+  if ! PATH="${PATH:-/usr/bin:/bin}" mkdir -p "${CHEZMOI_BIN_DIR}"; then
+    echo "Error: Failed to create CHEZMOI_BIN_DIR: ${CHEZMOI_BIN_DIR}" >&2
+    return 1
+  fi
+
+  if [[ ":${PATH:-}:" != *":${CHEZMOI_BIN_DIR}:"* ]]; then
+    export PATH="${CHEZMOI_BIN_DIR}:${PATH:-}"
+  fi
 }
 
 function run_chezmoi() {
-  setup_chezmoi_bin_dir
-
   if [ "${DRY_RUN}" = "true" ]; then
     echo "[DRY RUN] Would install chezmoi for ${GITHUB_USERNAME}"
     return 0
   fi
+
+  setup_chezmoi_bin_dir
 
   if command -v curl &>/dev/null; then
     echo "Using curl to download chezmoi installer..."


### PR DESCRIPTION
### Motivation
- Address valid reviewer comments on PR #135 to make the chezmoi installer safe in minimal/CI environments and prevent unintended side effects during dry-run. 
- Prevent duplicate PATH entries and avoid adding a non-existent bin directory to `PATH` if `mkdir` fails.

### Description
- Close #135
- Make `CHEZMOI_BIN_DIR` configurable and default it to `${HOME}/.local/bin`, and add explicit error handling so `setup_chezmoi_bin_dir` fails if `mkdir -p` cannot create the directory. 
- Prepend `CHEZMOI_BIN_DIR` to `PATH` idempotently and defensively using `${PATH:-}` so the function behaves correctly when `PATH` is empty or unset. 
- Keep `DRY_RUN=true` side-effect free by returning before any filesystem or `PATH` mutations, and update `install/common/chezmoi.bats` to behavioral tests that source the script within `bash -c` to avoid leaking strict mode into the test runner and to verify directory creation, idempotent PATH prepending, unset-PATH handling, and dry-run non-creation.

### Testing
- `bash -n install/common/chezmoi.sh` (syntax check) — succeeded. 
- Functional check: invoked `setup_chezmoi_bin_dir` twice in a temporary `HOME` with `PATH` set and asserted the directory exists and `PATH` was prepended only once — succeeded. 
- Functional check: ran `setup_chezmoi_bin_dir` with `PATH` unset in a temporary `HOME` and asserted the directory exists and `PATH` begins with the bin dir — succeeded. 
- Dry-run verification: `DRY_RUN=true HOME=<tmp> GITHUB_USERNAME=test-user bash install/common/chezmoi.sh` confirmed dry-run output and that `<tmp>/.local/bin` was not created — succeeded. 
- `bats install/common/chezmoi.bats` was not run here because `bats` is not installed in this environment, but the updated BATS tests are included and expected to run in CI or a developer environment with `bats` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fe3d125fc832da6282be877447ff0)

## Summary by Sourcery

Improve chezmoi installer bin-dir setup robustness and update associated BATS tests for behavior-based validation.

Bug Fixes:
- Ensure chezmoi bin directory creation fails loudly when mkdir cannot create the directory.
- Avoid duplicate or invalid PATH entries by idempotently prepending the chezmoi bin directory and handling empty or unset PATH values.
- Prevent dry-run executions from creating the bin directory or mutating PATH.

Enhancements:
- Make the chezmoi bin directory configurable via CHEZMOI_BIN_DIR with a default of ${HOME}/.local/bin.

Tests:
- Refactor chezmoi BATS tests to use temporary HOME directories and bash -c sourcing to verify directory creation, PATH prepending behavior, unset PATH handling, and dry-run non-creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made the install bin directory configurable via environment override.

* **Bug Fixes**
  * Improved setup robustness to avoid PATH duplication and handle an unset PATH.
  * Ensured dry-run mode does not create local bin directories or modify PATH.

* **Tests**
  * Added per-test temporary HOME isolation.
  * Expanded tests for idempotent setup, PATH handling, and dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->