### PR TITLE
fix(ci): improve macOS kcov coverage collection

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,26 +34,38 @@ jobs:
       - name: Install kcov
         run: brew install kcov
 
-      - name: Install Bats
-        run: brew install bats-core
+      - name: Install Bats and Bash
+        run: brew install bats-core bash
 
       - name: Run tests with coverage
         run: |
-          # Set environment variables for SimpleCov
           export DRY_RUN=true
 
-          # Run macOS-specific tests with coverage (kcov for performance)
-          # Only measure coverage for macOS-specific scripts
-          mkdir -p coverage
-          kcov --exclude-pattern=/usr,/opt/homebrew,/System coverage bats install/macos/
+          # Run tests (BATS) separately
+          bats install/macos/ install/common/ tests/files/
 
-          # Run common and file tests without coverage for speed
-          bats install/common/ tests/files/
+          # kcov + bats can fail on some bats-core internals, so measure script coverage directly
+          # Use Homebrew bash (instead of /bin/bash) to avoid kcov open errors on macOS runner
+          brew_prefix="$(brew --prefix)"
+          BASH_BIN="${brew_prefix}/bin/bash"
+          test -x "${BASH_BIN}"
+          bash_dir="$(dirname "${BASH_BIN}")"
+          export PATH="${bash_dir}:${PATH}"
+
+          mkdir -p coverage/raw
+          kcov --exclude-pattern=/usr,/opt/homebrew,/System coverage/raw/01-brew "${BASH_BIN}" install/macos/01-brew.sh
+          kcov --exclude-pattern=/usr,/opt/homebrew,/System coverage/raw/02-brew-packages "${BASH_BIN}" install/macos/02-brew-packages.sh
+          kcov --exclude-pattern=/usr,/opt/homebrew,/System coverage/raw/03-profile "${BASH_BIN}" install/macos/03-profile.sh
+          kcov --exclude-pattern=/usr,/opt/homebrew,/System coverage/raw/setup "${BASH_BIN}" install/macos/setup.sh
+
+          # Merge coverage reports and ensure Codecov input exists
+          kcov --merge coverage coverage/raw/01-brew coverage/raw/02-brew-packages coverage/raw/03-profile coverage/raw/setup
+          test -f coverage/cobertura.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ./coverage/coverage.json
+          files: ./coverage/cobertura.xml
           flags: macos
           name: coverage-macos
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f6d4f418832d8b787606fa8a8d7c)

## Summary by Sourcery

Adjust macOS CI workflow to run Bats tests separately and collect script coverage using kcov and Homebrew Bash, updating the coverage artifact uploaded to Codecov.

CI:
- Update macOS workflow to install Homebrew Bash alongside bats-core and use it for coverage runs to avoid kcov issues with the system shell.
- Change macOS CI to run Bats test suites without coverage, then execute individual installer scripts under kcov and merge their reports into a single coverage output.
- Switch Codecov upload on macOS to use the merged Cobertura XML report instead of the previous JSON coverage file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS CI workflow by enhancing test coverage collection and reporting methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->