### PR TITLE
fix: macOS CI coverage workflow review follow-ups

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,26 +34,53 @@ jobs:
       - name: Install kcov
         run: brew install kcov
 
-      - name: Install Bats
-        run: brew install bats-core
+      - name: Install Bats and Bash
+        run: brew install bats-core bash
 
       - name: Run tests with coverage
         run: |
-          # Set environment variables for SimpleCov
           export DRY_RUN=true
 
-          # Run macOS-specific tests with coverage (kcov for performance)
-          # Only measure coverage for macOS-specific scripts
-          mkdir -p coverage
-          kcov --exclude-pattern=/usr,/opt/homebrew,/System coverage bats install/macos/
+          # Run tests first
+          bats install/macos/ install/common/ tests/files/
 
-          # Run common and file tests without coverage for speed
-          bats install/common/ tests/files/
+          # kcov + bats can fail on macOS runners, so measure shell scripts directly.
+          brew_prefix="$(brew --prefix)"
+          BASH_BIN="${brew_prefix}/bin/bash"
+          test -x "${BASH_BIN}"
+
+          mkdir -p coverage/raw
+          kcov_target_scripts=(
+            install/macos/01-brew.sh
+            install/macos/02-brew-packages.sh
+            install/macos/03-profile.sh
+            install/macos/setup.sh
+            install/macos/brew-dump-explicit.sh
+          )
+
+          raw_dirs=()
+          for script in "${kcov_target_scripts[@]}"; do
+            name="$(basename "${script}" .sh)"
+            out_dir="coverage/raw/${name}"
+            raw_dirs+=("${out_dir}")
+            kcov --exclude-pattern=/usr,/opt/homebrew,/System "${out_dir}" "${BASH_BIN}" "${script}" || true
+          done
+
+          # Merge coverage reports and keep this step non-fatal when no report is generated.
+          if [ "${#raw_dirs[@]}" -gt 0 ]; then
+            kcov --merge coverage "${raw_dirs[@]}" || true
+          fi
+
+          if [ -f coverage/cobertura.xml ]; then
+            echo "coverage/cobertura.xml generated"
+          else
+            echo "coverage/cobertura.xml not generated; skipping strict validation"
+          fi
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ./coverage/coverage.json
+          files: ./coverage/cobertura.xml
           flags: macos
           name: coverage-macos
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -63,7 +63,13 @@ jobs:
             name="$(basename "${script}" .sh)"
             out_dir="coverage/raw/${name}"
             raw_dirs+=("${out_dir}")
-            kcov --exclude-pattern=/usr,/opt/homebrew,/System "${out_dir}" "${BASH_BIN}" "${script}" || true
+
+            # Keep installation scripts in DRY_RUN mode to avoid long CI execution.
+            if [[ "${script}" == install/macos/brew-dump-explicit.sh ]]; then
+              kcov --exclude-pattern=/usr,/opt/homebrew,/System "${out_dir}" "${BASH_BIN}" "${script}" || true
+            else
+              DRY_RUN=true kcov --exclude-pattern=/usr,/opt/homebrew,/System "${out_dir}" "${BASH_BIN}" "${script}" || true
+            fi
           done
 
           # Merge coverage reports and keep this step non-fatal when no report is generated.


### PR DESCRIPTION
### Motivation
- Address reviewer feedback to make macOS CI coverage collection more reliable and easier to maintain.
- Avoid failing the job when coverage artifacts are not produced on macOS runners.

### Description
- Updated `.github/workflows/ci-macos.yml` to run `bats` test suites first and then collect coverage by executing target scripts directly under `kcov`.
- Added `bash` to the install step and replaced duplicated `kcov` invocations with a loop over `kcov_target_scripts`, including `install/macos/brew-dump-explicit.sh` as a coverage target.
- Made the coverage merge and artifact validation non-fatal and switched the Codecov upload input to `coverage/cobertura.xml`.
- Close #143

### Testing
- Ran `npm ci` which completed successfully.
- Executed `scripts/install-tools.sh` to provision `shellcheck`, `shfmt`, `actionlint`, and `bats`, and it finished successfully.
- Ran pre-commit checks (Prettier and `actionlint`) via the repository hooks and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990fd5216e8832d833e88978b4086fa)

## Summary by Sourcery

Update the macOS CI workflow to run Bats tests before collecting coverage and to make coverage collection and upload more robust and non-fatal when coverage artifacts are missing.

CI:
- Adjust macOS workflow to run Bats test suites first and then collect coverage by executing target shell scripts directly under kcov using Homebrew Bash.
- Expand the set of macOS scripts included in coverage collection and merge per-script coverage outputs into a single report.
- Relax coverage generation and merge failures so the CI job does not fail when coverage output is missing, and switch Codecov uploads to use the Cobertura XML report.