### PR TITLE
fix: setup.sh をリポジトリ未クローン状態でも実行可能にする

### DIFF
--- a/.github/workflows/e2e-setup-test.yml
+++ b/.github/workflows/e2e-setup-test.yml
@@ -28,6 +28,7 @@ jobs:
           DOTFILES_DEBUG: "1"
           DRY_RUN: "true"
           DOTFILES_REPO: ${{ github.workspace }}/dotfiles-source
+          DOTFILES_CLONE_DIR: ${{ runner.temp }}/chezmoi-source
 
       - name: Verify bootstrap completed
         run: |

--- a/.github/workflows/e2e-setup-test.yml
+++ b/.github/workflows/e2e-setup-test.yml
@@ -6,6 +6,33 @@ on:
   workflow_dispatch: # 手動実行も可能に
 
 jobs:
+  setup-bootstrap:
+    name: Bootstrap (without pre-cloning)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          path: dotfiles-source
+
+      - name: Run setup.sh from standalone location (bootstrap test)
+        run: |
+          mkdir -p /tmp/bootstrap-test
+          cp dotfiles-source/setup.sh /tmp/bootstrap-test/
+          bash /tmp/bootstrap-test/setup.sh
+        env:
+          DOTFILES_DEBUG: "1"
+          DRY_RUN: "true"
+          DOTFILES_REPO: ${{ github.workspace }}/dotfiles-source
+
+      - name: Verify bootstrap completed
+        run: |
+          echo "Bootstrap test passed: setup.sh ran successfully without pre-cloning"
+
   setup:
     permissions:
       contents: read

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,23 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/yellow-seed/dotfiles.git}"
+
+function bootstrap_clone() {
+  if ! command -v git &>/dev/null; then
+    echo "Error: git is not installed. Please install git and try again." >&2
+    exit 1
+  fi
+
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  echo "Required scripts not found locally. Cloning dotfiles repository..."
+  git clone "${DOTFILES_REPO}" "${temp_dir}/dotfiles"
+  bash "${temp_dir}/dotfiles/setup.sh"
+  local exit_code=$?
+  rm -rf "${temp_dir}"
+  exit ${exit_code}
+}
 
 function run_script() {
   local script_path="$1"
@@ -19,6 +36,10 @@ function run_script() {
 }
 
 function main() {
+  if [ ! -d "${SCRIPT_DIR}/install" ]; then
+    bootstrap_clone
+  fi
+
   local os_type
   os_type="$(uname)"
 

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,7 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/yellow-seed/dotfiles.git}"
+DOTFILES_CLONE_DIR="${DOTFILES_CLONE_DIR:-${HOME}/.local/share/chezmoi}"
 
 function bootstrap_clone() {
   if ! command -v git &>/dev/null; then
@@ -14,14 +15,14 @@ function bootstrap_clone() {
     exit 1
   fi
 
-  local temp_dir
-  temp_dir="$(mktemp -d)"
-  echo "Required scripts not found locally. Cloning dotfiles repository..."
-  git clone "${DOTFILES_REPO}" "${temp_dir}/dotfiles"
-  bash "${temp_dir}/dotfiles/setup.sh"
-  local exit_code=$?
-  rm -rf "${temp_dir}"
-  exit ${exit_code}
+  if [ ! -d "${DOTFILES_CLONE_DIR}" ]; then
+    echo "Required scripts not found locally. Cloning dotfiles repository..."
+    mkdir -p "$(dirname "${DOTFILES_CLONE_DIR}")"
+    git clone "${DOTFILES_REPO}" "${DOTFILES_CLONE_DIR}"
+  fi
+
+  bash "${DOTFILES_CLONE_DIR}/setup.sh"
+  exit $?
 }
 
 function run_script() {

--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,12 @@ function bootstrap_clone() {
     exit 1
   fi
 
-  if [ ! -d "${DOTFILES_CLONE_DIR}" ]; then
+  if [ ! -f "${DOTFILES_CLONE_DIR}/setup.sh" ] || [ ! -d "${DOTFILES_CLONE_DIR}/install" ]; then
+    if [ -e "${DOTFILES_CLONE_DIR}" ]; then
+      echo "Error: ${DOTFILES_CLONE_DIR} exists but is not a valid dotfiles checkout." >&2
+      echo "Set DOTFILES_CLONE_DIR to an empty path, or remove the directory and retry." >&2
+      exit 1
+    fi
     echo "Required scripts not found locally. Cloning dotfiles repository..."
     mkdir -p "$(dirname "${DOTFILES_CLONE_DIR}")"
     git clone "${DOTFILES_REPO}" "${DOTFILES_CLONE_DIR}"

--- a/tests/files/setup.bats
+++ b/tests/files/setup.bats
@@ -50,22 +50,28 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "setup.sh uses DOTFILES_CLONE_DIR variable for clone destination" {
+  run grep -q "DOTFILES_CLONE_DIR" "${SETUP_SCRIPT}"
+  [ "$status" -eq 0 ]
+}
+
 @test "setup.sh bootstrap checks for git availability" {
   run grep -q "command -v git" "${SETUP_SCRIPT}"
   [ "$status" -eq 0 ]
 }
 
 @test "setup.sh triggers bootstrap when install directory is missing" {
-  local temp_dir fake_bin
+  local temp_dir fake_bin clone_dir
   temp_dir="$(mktemp -d)"
   fake_bin="$(mktemp -d)"
+  clone_dir="${temp_dir}/clone"  # 存在しないパスでブートストラップを誘発
   cp "${SETUP_SCRIPT}" "${temp_dir}/"
 
   # Mock git to fail after bootstrap message is printed
   printf '#!/usr/bin/env bash\nexit 1\n' >"${fake_bin}/git"
   chmod +x "${fake_bin}/git"
 
-  run bash -c "PATH='${fake_bin}:${PATH}' bash '${temp_dir}/setup.sh'"
+  run bash -c "DOTFILES_CLONE_DIR='${clone_dir}' PATH='${fake_bin}:${PATH}' bash '${temp_dir}/setup.sh'"
 
   rm -rf "${temp_dir}" "${fake_bin}"
 

--- a/tests/files/setup.bats
+++ b/tests/files/setup.bats
@@ -34,3 +34,23 @@ setup() {
   run grep -q "install/common/chezmoi.sh" "${SETUP_SCRIPT}"
   [ "$status" -eq 0 ]
 }
+
+@test "setup.sh has bootstrap_clone function" {
+  run grep -q "bootstrap_clone" "${SETUP_SCRIPT}"
+  [ "$status" -eq 0 ]
+}
+
+@test "setup.sh checks for install directory before running" {
+  run grep -q 'SCRIPT_DIR}/install' "${SETUP_SCRIPT}"
+  [ "$status" -eq 0 ]
+}
+
+@test "setup.sh uses DOTFILES_REPO variable for clone URL" {
+  run grep -q "DOTFILES_REPO" "${SETUP_SCRIPT}"
+  [ "$status" -eq 0 ]
+}
+
+@test "setup.sh bootstrap checks for git availability" {
+  run grep -q "command -v git" "${SETUP_SCRIPT}"
+  [ "$status" -eq 0 ]
+}

--- a/tests/files/setup.bats
+++ b/tests/files/setup.bats
@@ -54,3 +54,21 @@ setup() {
   run grep -q "command -v git" "${SETUP_SCRIPT}"
   [ "$status" -eq 0 ]
 }
+
+@test "setup.sh triggers bootstrap when install directory is missing" {
+  local temp_dir fake_bin
+  temp_dir="$(mktemp -d)"
+  fake_bin="$(mktemp -d)"
+  cp "${SETUP_SCRIPT}" "${temp_dir}/"
+
+  # Mock git to fail after bootstrap message is printed
+  printf '#!/usr/bin/env bash\nexit 1\n' >"${fake_bin}/git"
+  chmod +x "${fake_bin}/git"
+
+  run bash -c "PATH='${fake_bin}:${PATH}' bash '${temp_dir}/setup.sh'"
+
+  rm -rf "${temp_dir}" "${fake_bin}"
+
+  [[ "$output" =~ "Required scripts not found locally" ]]
+}
+

--- a/tests/files/setup.bats
+++ b/tests/files/setup.bats
@@ -75,6 +75,7 @@ setup() {
 
   rm -rf "${temp_dir}" "${fake_bin}"
 
+  [ "$status" -ne 0 ]
   [[ "$output" =~ "Required scripts not found locally" ]]
 }
 


### PR DESCRIPTION
## Description

`setup.sh` はリポジトリ内の他スクリプトを相対パスで呼び出しているため、リポジトリをクローンせずに実行するとエラーになっていました。

```bash
# 以前はこれが動作しなかった
bash <(curl -fsLS https://raw.githubusercontent.com/yellow-seed/dotfiles/main/setup.sh)
```

`bootstrap_clone` 関数を追加し、`install/` ディレクトリが存在しない場合にリポジトリを chezmoi のソースディレクトリ（`~/.local/share/chezmoi`）へ直接クローンして再実行するように対応しました。一時ディレクトリを使わず chezmoi が使用するパスに直接クローンするため、後続の `chezmoi init` がそのリポジトリをそのまま利用できます。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## Related Issues

<!-- 関連Issueがあれば記載 -->

## Changes Made

- **`setup.sh`**: `bootstrap_clone` 関数を追加
  - `install/` ディレクトリが存在しない場合に自動でクローン＆再実行
  - クローン先は `~/.local/share/chezmoi`（chezmoi デフォルトのソースディレクトリ）
  - `DOTFILES_REPO` 環境変数でクローン元 URL を上書き可能
  - `DOTFILES_CLONE_DIR` 環境変数でクローン先を上書き可能（テスト・フォーク対応）
  - git が未インストールの場合は明確なエラーメッセージを表示

- **`tests/files/setup.bats`**: ブートストラップのテストを追加
  - 静的チェック: `bootstrap_clone` 関数、`DOTFILES_CLONE_DIR`、`DOTFILES_REPO`、git チェックの存在確認
  - 機能テスト: `install/` がない状態で実行したとき bootstrap メッセージが出ることを検証（`DOTFILES_CLONE_DIR` で環境依存を排除）

- **`.github/workflows/e2e-setup-test.yml`**: `setup-bootstrap` E2E ジョブを追加
  - `setup.sh` のみをコピーした状態（`install/` なし）から起動し、ブートストラップ経由のセットアップを検証
  - Ubuntu runner 使用（`install/ubuntu/setup.sh` がスタブのため副作用なし）
  - `DRY_RUN=true` で実際のインストールをスキップ
  - `DOTFILES_REPO` にローカルチェックアウトを指定してネットワーク不要で検証

## Testing

- [x] テストを追加/更新しました
- [x] 既存のテストがすべて通過します（shellcheck / shfmt / actionlint パス済み）
- [x] 手動で動作確認しました（`DOTFILES_CLONE_DIR` を使ったブートストラップ動作確認）

## Checklist

- [x] コードはプロジェクトのスタイルガイドに従っています
- [x] 自己レビューを実施しました
- [x] 関連するドキュメントを更新しました
- [x] 変更によって新しい警告は発生していません
- [x] テストを追加/更新しました
- [x] すべてのテストが通過します

## Additional Notes

環境変数による制御:

| 変数 | デフォルト | 用途 |
|---|---|---|
| `DOTFILES_REPO` | `https://github.com/yellow-seed/dotfiles.git` | クローン元 URL |
| `DOTFILES_CLONE_DIR` | `~/.local/share/chezmoi` | クローン先ディレクトリ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow setup.sh to bootstrap by cloning the dotfiles repository when run standalone without a pre-cloned repo, and add coverage to ensure this workflow works end-to-end.

New Features:
- Introduce a bootstrap flow in setup.sh that clones the dotfiles repository to a configurable directory and re-runs the script.
- Support DOTFILES_REPO and DOTFILES_CLONE_DIR environment variables to customize the clone source and destination for bootstrapping.

Bug Fixes:
- Prevent setup.sh from failing when executed outside a cloned repository by bootstrapping the required scripts.

Tests:
- Add unit-style Bats tests to validate the presence and behavior of the bootstrap logic and related environment variables in setup.sh.
- Add a CI E2E workflow job that runs setup.sh from a standalone location to verify bootstrap-based setup on Ubuntu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now supports bootstrapping from a remote dotfiles repository when required components are missing locally. You can customize behavior via DOTFILES_REPO and DOTFILES_CLONE_DIR.

* **Tests**
  * Added CI workflow and automated tests that verify the bootstrap behavior and error handling when required scripts are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->