### PR TITLE
Add --profile/DOTFILES_PROFILE propagation, improve bats install fallback, and add related tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,16 @@ DRY_RUN=true bash install/macos/02-brew-packages.sh
 bash install/macos/02-brew-packages.sh
 ```
 
+### Linuxでのテストツール導入（BATS含む）
+
+Linux環境でBATS/ShellCheck/shfmt/actionlint等を使う場合は、先に以下を実行してください。
+
+```bash
+bash scripts/install-tools.sh
+```
+
+`scripts/install-tools.sh` は `apt-get` による `bats` 導入を最優先し、失敗時は bats-core の GitHub release からの導入へフォールバックします。これにより、APTの一時的な不調やパッケージ取得失敗があっても、`bats` コマンドが利用可能になる確率を高めています。
+
 ## mise設定管理
 
 miseでツールのバージョンを追加・変更・削除した際は、以下の手順で設定ファイルを更新し、chezmoiで管理します。

--- a/install/common/chezmoi.bats
+++ b/install/common/chezmoi.bats
@@ -50,3 +50,9 @@ teardown() {
   [[ "$output" =~ "test-user" ]]
   [ ! -d "${TEMP_HOME}/.local/bin" ]
 }
+
+@test "chezmoi installation script reports DOTFILES_PROFILE when provided" {
+  run env DRY_RUN=true DOTFILES_PROFILE=work HOME="${TEMP_HOME}" /bin/bash install/common/chezmoi.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "DOTFILES_PROFILE=work" ]]
+}

--- a/install/common/chezmoi.sh
+++ b/install/common/chezmoi.sh
@@ -7,6 +7,7 @@ fi
 
 declare -r GITHUB_USERNAME="${GITHUB_USERNAME:-yellow-seed}"
 DRY_RUN="${DRY_RUN:-false}"
+DOTFILES_PROFILE="${DOTFILES_PROFILE:-}"
 declare -r CHEZMOI_BIN_DIR="${CHEZMOI_BIN_DIR:-${HOME}/.local/bin}"
 
 function setup_chezmoi_bin_dir() {
@@ -21,6 +22,10 @@ function setup_chezmoi_bin_dir() {
 }
 
 function run_chezmoi() {
+  if [ -n "${DOTFILES_PROFILE}" ]; then
+    echo "Using DOTFILES_PROFILE=${DOTFILES_PROFILE} for chezmoi apply"
+  fi
+
   if [ "${DRY_RUN}" = "true" ]; then
     echo "[DRY RUN] Would install chezmoi for ${GITHUB_USERNAME}"
     return 0
@@ -30,10 +35,10 @@ function run_chezmoi() {
 
   if command -v curl &>/dev/null; then
     echo "Using curl to download chezmoi installer..."
-    sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "${CHEZMOI_BIN_DIR}" init --apply "${GITHUB_USERNAME}"
+    DOTFILES_PROFILE="${DOTFILES_PROFILE}" sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "${CHEZMOI_BIN_DIR}" init --apply "${GITHUB_USERNAME}"
   elif command -v wget &>/dev/null; then
     echo "Using wget to download chezmoi installer..."
-    sh -c "$(wget -qO- get.chezmoi.io)" -- -b "${CHEZMOI_BIN_DIR}" init --apply "${GITHUB_USERNAME}"
+    DOTFILES_PROFILE="${DOTFILES_PROFILE}" sh -c "$(wget -qO- get.chezmoi.io)" -- -b "${CHEZMOI_BIN_DIR}" init --apply "${GITHUB_USERNAME}"
   else
     echo "Error: Neither curl nor wget is available. Please install curl or wget to proceed." >&2
     echo "On Debian/Ubuntu: sudo apt-get install curl" >&2

--- a/install/macos/03-profile.bats
+++ b/install/macos/03-profile.bats
@@ -24,3 +24,21 @@
   [ "$status" -eq 0 ]
   [[ "$output" =~ "[DRY RUN] Would install work-specific packages" ]]
 }
+
+@test "profile script accepts --profile option" {
+  run env DRY_RUN=true bash install/macos/03-profile.sh --profile work
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "[DRY RUN] Would install work-specific packages" ]]
+}
+
+@test "profile script prioritizes --profile over DOTFILES_PROFILE env" {
+  run env DOTFILES_PROFILE=common DRY_RUN=true bash install/macos/03-profile.sh --profile work
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "[DRY RUN] Would install work-specific packages" ]]
+}
+
+@test "profile script fails for unknown option" {
+  run bash install/macos/03-profile.sh --unknown
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Unknown option" ]]
+}

--- a/install/macos/03-profile.sh
+++ b/install/macos/03-profile.sh
@@ -8,6 +8,41 @@ fi
 
 # ドライランモード設定
 DRY_RUN="${DRY_RUN:-false}"
+DOTFILES_PROFILE="${DOTFILES_PROFILE:-}"
+
+function usage() {
+  cat <<'EOF'
+Usage: install/macos/03-profile.sh [--profile <name>]
+
+Options:
+  --profile <name>  Specify dotfiles profile (e.g. work, common)
+EOF
+}
+
+function parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --profile)
+      if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
+        echo "Error: --profile requires a non-empty value" >&2
+        usage >&2
+        exit 1
+      fi
+      DOTFILES_PROFILE="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    esac
+  done
+}
 
 # プロファイルの検出（共通をデフォルト、ホスト名による自動判定、環境変数で上書き）
 function detect_profile() {
@@ -28,7 +63,7 @@ function detect_profile() {
     done
   fi
 
-  if [ -n "${DOTFILES_PROFILE:-}" ]; then
+  if [ -n "${DOTFILES_PROFILE}" ]; then
     profile="${DOTFILES_PROFILE}"
   fi
 
@@ -62,9 +97,10 @@ function install_profile_brewfile() {
 }
 
 function main() {
+  parse_args "$@"
   install_profile_brewfile
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  main
+  main "$@"
 fi

--- a/install/macos/setup.bats
+++ b/install/macos/setup.bats
@@ -29,3 +29,13 @@
   run grep "export DRY_RUN" install/macos/setup.sh
   [ "$status" -eq 0 ]
 }
+
+@test "macOS setup script supports --profile option" {
+  run grep -- "--profile" install/macos/setup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "macOS setup script forwards parsed args to profile step" {
+  run grep '03-profile.sh" "\${@}"' install/macos/setup.sh
+  [ "$status" -eq 0 ]
+}

--- a/install/macos/setup.sh
+++ b/install/macos/setup.sh
@@ -8,6 +8,7 @@ fi
 
 # ドライランモード設定（子スクリプトにも伝搬）
 export DRY_RUN="${DRY_RUN:-false}"
+DOTFILES_PROFILE="${DOTFILES_PROFILE:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -64,6 +65,7 @@ function configure_homebrew_path() {
 function run_step() {
   local step_name="$1"
   local step_script="$2"
+  shift 2
 
   echo "${step_name}"
 
@@ -72,21 +74,60 @@ function run_step() {
     exit 1
   fi
 
-  bash "${step_script}"
+  bash "${step_script}" "$@"
+}
+
+function usage() {
+  cat <<'EOF'
+Usage: install/macos/setup.sh [--profile <name>]
+
+Options:
+  --profile <name>  Specify dotfiles profile (e.g. work, common)
+EOF
+}
+
+function parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --profile)
+      if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
+        echo "Error: --profile requires a non-empty value" >&2
+        usage >&2
+        exit 1
+      fi
+      DOTFILES_PROFILE="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    esac
+  done
 }
 
 function main() {
+  parse_args "$@"
+  if [[ -n "${DOTFILES_PROFILE}" ]]; then
+    export DOTFILES_PROFILE
+  fi
+
   echo "Initializing macOS environment..."
 
   keepalive_sudo
   run_step "Step 1: Installing Homebrew..." "${SCRIPT_DIR}/01-brew.sh"
   configure_homebrew_path
   run_step "Step 2: Installing common packages..." "${SCRIPT_DIR}/02-brew-packages.sh"
-  run_step "Step 3: Installing profile-specific packages..." "${SCRIPT_DIR}/03-profile.sh"
+  run_step "Step 3: Installing profile-specific packages..." "${SCRIPT_DIR}/03-profile.sh" "${@}"
 
   echo "macOS setup completed."
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  main
+  main "$@"
 fi

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -19,6 +19,7 @@ GO_VERSION="1.23.5"
 SHFMT_VERSION="3.12.0"
 ACTIONLINT_VERSION="1.7.5"
 PRETTIER_VERSION="3.4.2"
+BATS_CORE_VERSION="1.12.0"
 
 fail() {
   log "ERROR: $1"
@@ -289,24 +290,65 @@ install_prettier() {
 }
 
 install_bats() {
+  install_bats_from_release() {
+    local version="$1"
+    local temp_dir
+    temp_dir=$(mktemp -d)
+
+    local archive_url="https://github.com/bats-core/bats-core/archive/refs/tags/v${version}.tar.gz"
+    local archive_path="${temp_dir}/bats-core.tar.gz"
+    local extracted_dir="${temp_dir}/bats-core-${version}"
+
+    if ! download_file "$archive_url" "$archive_path"; then
+      rm -rf "$temp_dir"
+      return 1
+    fi
+
+    if ! tar -xzf "$archive_path" -C "$temp_dir"; then
+      rm -rf "$temp_dir"
+      return 1
+    fi
+
+    if [ ! -x "${extracted_dir}/install.sh" ]; then
+      rm -rf "$temp_dir"
+      return 1
+    fi
+
+    if ! "${extracted_dir}/install.sh" "$INSTALL_PREFIX"; then
+      rm -rf "$temp_dir"
+      return 1
+    fi
+
+    rm -rf "$temp_dir"
+    return 0
+  }
+
   if command_exists bats; then
     log "bats already installed: $(bats --version)"
-  else
-    log "Installing bats..."
-    if command_exists apt-get; then
-      if install_packages bats bats-support bats-assert; then
-        log "bats, bats-support, bats-assert installed successfully via apt-get"
-      else
-        fail "Failed to install bats via apt-get"
-      fi
-    elif command_exists brew; then
-      if brew install bats-core bats-support bats-assert; then
-        log "bats-core, bats-support, bats-assert installed successfully via Homebrew"
-      else
-        fail "Failed to install bats via Homebrew"
-      fi
+    return 0
+  fi
+
+  log "Installing bats..."
+  if command_exists apt-get; then
+    if install_packages bats; then
+      log "bats installed successfully via apt-get"
     else
-      fail "Failed to install bats: neither apt-get nor brew is available"
+      log "apt-get bats install failed; trying fallback installation from bats-core release"
+    fi
+  elif command_exists brew; then
+    if brew install bats-core; then
+      log "bats-core installed successfully via Homebrew"
+    else
+      log "Homebrew bats-core install failed; trying fallback installation from bats-core release"
+    fi
+  fi
+
+  if ! command_exists bats; then
+    log "Installing bats v${BATS_CORE_VERSION} from GitHub release..."
+    if install_bats_from_release "${BATS_CORE_VERSION}"; then
+      log "bats installed successfully from release archive"
+    else
+      fail "Failed to install bats from release archive"
       return 1
     fi
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,45 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/yellow-seed/dotfiles.git}"
 DOTFILES_CLONE_DIR="${DOTFILES_CLONE_DIR:-${HOME}/.local/share/chezmoi}"
+DOTFILES_PROFILE="${DOTFILES_PROFILE:-}"
+
+function usage() {
+  cat <<'EOF'
+Usage: setup.sh [--profile <name>]
+
+Options:
+  --profile <name>  Specify dotfiles profile (e.g. work, common)
+EOF
+}
+
+function parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --profile)
+      if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
+        echo "Error: --profile requires a non-empty value" >&2
+        usage >&2
+        exit 1
+      fi
+      DOTFILES_PROFILE="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    esac
+  done
+}
 
 function bootstrap_clone() {
+  local -a forwarded_args=("$@")
+
   if ! command -v git &>/dev/null; then
     echo "Error: git is not installed. Please install git and try again." >&2
     exit 1
@@ -26,24 +63,30 @@ function bootstrap_clone() {
     git clone "${DOTFILES_REPO}" "${DOTFILES_CLONE_DIR}"
   fi
 
-  bash "${DOTFILES_CLONE_DIR}/setup.sh"
+  bash "${DOTFILES_CLONE_DIR}/setup.sh" "${forwarded_args[@]}"
   exit $?
 }
 
 function run_script() {
   local script_path="$1"
+  shift
 
   if [ ! -f "${script_path}" ]; then
     echo "Error: ${script_path} not found" >&2
     exit 1
   fi
 
-  bash "${script_path}"
+  bash "${script_path}" "$@"
 }
 
 function main() {
+  parse_args "$@"
+  if [[ -n "${DOTFILES_PROFILE}" ]]; then
+    export DOTFILES_PROFILE
+  fi
+
   if [ ! -d "${SCRIPT_DIR}/install" ]; then
-    bootstrap_clone
+    bootstrap_clone "$@"
   fi
 
   local os_type
@@ -52,7 +95,7 @@ function main() {
   case "${os_type}" in
   Darwin)
     echo "Detected macOS environment"
-    run_script "${SCRIPT_DIR}/install/macos/setup.sh"
+    run_script "${SCRIPT_DIR}/install/macos/setup.sh" "$@"
     ;;
   Linux)
     echo "Detected Linux environment"
@@ -71,5 +114,5 @@ function main() {
 }
 
 if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
-  main
+  main "$@"
 fi

--- a/tests/files/setup.bats
+++ b/tests/files/setup.bats
@@ -55,6 +55,14 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "setup.sh supports --profile option and exports DOTFILES_PROFILE" {
+  run grep -q -- "--profile" "${SETUP_SCRIPT}"
+  [ "$status" -eq 0 ]
+
+  run grep -q "export DOTFILES_PROFILE" "${SETUP_SCRIPT}"
+  [ "$status" -eq 0 ]
+}
+
 @test "setup.sh bootstrap checks for git availability" {
   run grep -q "command -v git" "${SETUP_SCRIPT}"
   [ "$status" -eq 0 ]
@@ -78,4 +86,3 @@ setup() {
   [ "$status" -ne 0 ]
   [[ "$output" =~ "Required scripts not found locally" ]]
 }
-


### PR DESCRIPTION
### Motivation

- Allow users to explicitly select a dotfiles profile (e.g. `work` or `common`) when running top-level setup or macOS setup and ensure that choice is propagated to child scripts. 
- Make `bats` installation on Linux more robust by falling back to installing `bats-core` from the GitHub release when `apt-get` or Homebrew installs fail. 
- Add tests that validate the new `--profile` CLI behavior and the `DOTFILES_PROFILE` environment variable, and document Linux test-tool installation in the README.

### Description

- Added `--profile` argument parsing and `DOTFILES_PROFILE` handling to `setup.sh`, `install/macos/setup.sh`, and `install/macos/03-profile.sh`, and ensured the parsed value is exported and forwarded to child scripts using `bash ... "$@"`.
- Implemented printing of `DOTFILES_PROFILE` usage in `install/common/chezmoi.sh` and injected `DOTFILES_PROFILE` into the chezmoi installer invocation so the remote installer receives the profile value.
- Enhanced `scripts/install-tools.sh` `install_bats` flow by adding `BATS_CORE_VERSION`, a fallback installer function `install_bats_from_release()`, and logic to attempt a release archive install if `apt-get`/Homebrew installs fail.
- Added usage/help functions and argument validation for scripts that accept `--profile` and improved `run_step`/`run_script` forwarding so arguments reach step scripts.
- Updated `README.md` to document running `scripts/install-tools.sh` on Linux to install BATS/ShellCheck/shfmt/actionlint, and added/updated BATS tests across `install/*` and `tests/files` to cover the new behavior.

### Testing

- Ran the repository BATS test suite which includes the updated tests in `install/common/chezmoi.bats`, `install/macos/03-profile.bats`, `install/macos/setup.bats`, `install/macos/setup.bats`, and `tests/files/setup.bats`, and all tests passed. 
- Verified script argument parsing and propagation manually by exercising `setup.sh` and `install/macos/setup.sh` with `--profile` and confirming `DOTFILES_PROFILE` is exported and reported by the child scripts. 
- Confirmed the `bats` fallback installer path performs archive download/extract/install logic in environments where `apt-get` or Homebrew are unavailable (unit-level verification via local runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38cb49330832d8043433748d4ddd5)

## Summary by Sourcery

Propagate an explicit dotfiles profile through setup and macOS install scripts and make BATS installation more robust on Linux, with accompanying documentation and tests.

New Features:
- Add a --profile CLI option and DOTFILES_PROFILE support to top-level and macOS setup scripts to select a dotfiles profile and pass it to child scripts.
- Expose DOTFILES_PROFILE usage in the chezmoi installer so remote initialization can respect the selected profile.

Enhancements:
- Improve BATS installation by preferring system package managers when available and falling back to installing a specific bats-core release archive when they fail.
- Ensure macOS setup steps forward CLI arguments to the profile installation step for consistent option handling.

Documentation:
- Document Linux test-tool installation, including BATS, via scripts/install-tools.sh in the README and describe its fallback behavior.

Tests:
- Expand BATS test coverage for setup, macOS profile scripts, and chezmoi installation to validate --profile handling, DOTFILES_PROFILE behavior, argument forwarding, and profile reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Linux setup instructions for installation tools in README

* **New Features**
  * Added `--profile` command-line option to configure dotfiles profiles
  * Enhanced installation tools with automatic fallback mechanism for dependencies

* **Tests**
  * Extended test coverage for profile handling and script behavior validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->