### PR TITLE
Add phase 1 nix-darwin flake/module, README notes, and bats tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,3 +609,41 @@ docker compose run --rm windows-test-shell
 - `chezmoi apply`を実行する前に`chezmoi diff`で変更内容を確認することを推奨
 - 重要な設定変更は必ずブランチを作成して作業する
 - コミットメッセージは[Conventional Commits](https://www.conventionalcommits.org/)の形式に従う
+
+## nix-darwin（Phase 1）
+
+Issue #158 の Phase 1 として、既存の chezmoi / Homebrew / mise を維持したまま、nix-darwin の最小構成を追加しています。
+
+### 追加したファイル
+
+- `macos/nix/flake.nix`: nix-darwin の flake エントリポイント
+- `macos/nix/darwin/default.nix`: nix-darwin の最小モジュール
+
+### セットアップ手順（macOS）
+
+1. Determinate Systems インストーラーで Nix を導入
+
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+
+2. flake を検証
+
+   ```bash
+   cd macos/nix
+   nix flake check
+   ```
+
+3. 適用（Apple Silicon の例）
+
+   ```bash
+   sudo darwin-rebuild switch --flake .#dotfiles
+   ```
+
+4. 適用（Intel Mac の例）
+
+   ```bash
+   sudo darwin-rebuild switch --flake .#dotfiles-intel
+   ```
+
+> ホスト名を独自名で運用する場合は `macos/nix/flake.nix` の `darwinConfigurations` を環境に合わせて変更してください。

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ Issue #158 の Phase 1 として、既存の chezmoi / Homebrew / mise を維持
 
 ### 追加したファイル
 
-- `macos/nix/flake.nix`: nix-darwin の flake エントリポイント
+- `macos/nix/flake.nix`: nix-darwin の flake エントリーポイント
 - `macos/nix/darwin/default.nix`: nix-darwin の最小モジュール
 
 ### セットアップ手順（macOS）

--- a/macos/nix/darwin/default.nix
+++ b/macos/nix/darwin/default.nix
@@ -1,0 +1,22 @@
+{ config, pkgs, ... }:
+{
+  # nix-darwin が要求する必須設定
+  system.stateVersion = 5;
+
+  # Determinate Systems の Nix を利用する場合は false を維持
+  nix.enable = false;
+
+  # Nix 実験的機能
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  # 既存の chezmoi / Homebrew / mise を維持しながら段階導入
+  environment.systemPackages = with pkgs; [
+    git
+  ];
+
+  # touch ID for sudo はローカルユーザー体験改善のため有効化
+  security.pam.services.sudo_local.touchIdAuth = true;
+}

--- a/macos/nix/darwin/default.nix
+++ b/macos/nix/darwin/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 {
   # nix-darwin が要求する必須設定
   system.stateVersion = 5;
@@ -6,11 +6,13 @@
   # Determinate Systems の Nix を利用する場合は false を維持
   nix.enable = false;
 
-  # Nix 実験的機能
-  nix.settings.experimental-features = [
-    "nix-command"
-    "flakes"
-  ];
+  # nix-darwin で Nix を管理する場合のみ nix.conf 設定を反映
+  nix.settings = lib.mkIf config.nix.enable {
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+  };
 
   # 既存の chezmoi / Homebrew / mise を維持しながら段階導入
   environment.systemPackages = with pkgs; [

--- a/macos/nix/flake.nix
+++ b/macos/nix/flake.nix
@@ -17,8 +17,9 @@
       ...
     }:
     let
-      defaultHost = "dotfiles";
-      intelHost = "dotfiles-intel";
+      baseHost = "dotfiles";
+      defaultHost = baseHost;
+      intelHost = "${baseHost}-intel";
       mkDarwinSystem = hostName: system:
         nix-darwin.lib.darwinSystem {
           modules = [
@@ -37,8 +38,8 @@
       };
 
       checks = {
-        darwin-aarch64 = self.darwinConfigurations."${defaultHost}".system;
-        darwin-x86_64 = self.darwinConfigurations."${intelHost}".system;
+        aarch64-darwin.default = self.darwinConfigurations."${defaultHost}".system;
+        x86_64-darwin.default = self.darwinConfigurations."${intelHost}".system;
       };
     };
 }

--- a/macos/nix/flake.nix
+++ b/macos/nix/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "dotfiles - nix-darwin configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    nix-darwin = {
+      url = "github:LnL7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nix-darwin,
+      ...
+    }:
+    let
+      defaultHost = "dotfiles";
+      intelHost = "dotfiles-intel";
+      mkDarwinSystem = hostName: system:
+        nix-darwin.lib.darwinSystem {
+          modules = [
+            ./darwin/default.nix
+            {
+              networking.hostName = hostName;
+              nixpkgs.hostPlatform = system;
+            }
+          ];
+        };
+    in
+    {
+      darwinConfigurations = {
+        "${defaultHost}" = mkDarwinSystem defaultHost "aarch64-darwin";
+        "${intelHost}" = mkDarwinSystem intelHost "x86_64-darwin";
+      };
+
+      checks = {
+        darwin-aarch64 = self.darwinConfigurations."${defaultHost}".system;
+        darwin-x86_64 = self.darwinConfigurations."${intelHost}".system;
+      };
+    };
+}

--- a/tests/files/nix-darwin.bats
+++ b/tests/files/nix-darwin.bats
@@ -9,21 +9,41 @@
 }
 
 @test "flake defines nix-darwin input" {
-  run grep -q 'nix-darwin' macos/nix/flake.nix
+  run grep -Eq '^[[:space:]]*url = "github:LnL7/nix-darwin";$' macos/nix/flake.nix
   [ "$status" -eq 0 ]
 }
 
-@test "flake defines darwinConfigurations" {
-  run grep -q 'darwinConfigurations' macos/nix/flake.nix
+@test "flake derives host names from base host" {
+  run grep -Eq '^[[:space:]]*intelHost = "\$\{baseHost\}-intel";$' macos/nix/flake.nix
+  [ "$status" -eq 0 ]
+}
+
+@test "flake defines Apple Silicon darwin configuration" {
+  run grep -Eq '^[[:space:]]*"\$\{defaultHost\}" = mkDarwinSystem defaultHost "aarch64-darwin";$' macos/nix/flake.nix
+  [ "$status" -eq 0 ]
+}
+
+@test "flake defines Intel darwin configuration" {
+  run grep -Eq '^[[:space:]]*"\$\{intelHost\}" = mkDarwinSystem intelHost "x86_64-darwin";$' macos/nix/flake.nix
+  [ "$status" -eq 0 ]
+}
+
+@test "flake checks follow system-keyed output schema" {
+  run grep -Eq '^[[:space:]]*aarch64-darwin\.default = self\.darwinConfigurations\."\$\{defaultHost\}"\.system;$' macos/nix/flake.nix
   [ "$status" -eq 0 ]
 }
 
 @test "darwin module configures required stateVersion" {
-  run grep -q 'system.stateVersion' macos/nix/darwin/default.nix
+  run grep -Eq '^[[:space:]]*system\.stateVersion = 5;$' macos/nix/darwin/default.nix
   [ "$status" -eq 0 ]
 }
 
 @test "darwin module disables nix when using Determinate installer" {
-  run grep -q 'nix.enable = false' macos/nix/darwin/default.nix
+  run grep -Eq '^[[:space:]]*nix\.enable = false;$' macos/nix/darwin/default.nix
+  [ "$status" -eq 0 ]
+}
+
+@test "darwin module applies nix settings only when nix-darwin manages nix" {
+  run grep -Eq '^[[:space:]]*nix\.settings = lib\.mkIf config\.nix\.enable \{$' macos/nix/darwin/default.nix
   [ "$status" -eq 0 ]
 }

--- a/tests/files/nix-darwin.bats
+++ b/tests/files/nix-darwin.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+@test "nix flake file exists" {
+  [ -f "macos/nix/flake.nix" ]
+}
+
+@test "nix-darwin default module exists" {
+  [ -f "macos/nix/darwin/default.nix" ]
+}
+
+@test "flake defines nix-darwin input" {
+  run grep -q 'nix-darwin' macos/nix/flake.nix
+  [ "$status" -eq 0 ]
+}
+
+@test "flake defines darwinConfigurations" {
+  run grep -q 'darwinConfigurations' macos/nix/flake.nix
+  [ "$status" -eq 0 ]
+}
+
+@test "darwin module configures required stateVersion" {
+  run grep -q 'system.stateVersion' macos/nix/darwin/default.nix
+  [ "$status" -eq 0 ]
+}
+
+@test "darwin module disables nix when using Determinate installer" {
+  run grep -q 'nix.enable = false' macos/nix/darwin/default.nix
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
### Motivation
- Introduce a minimal, non-disruptive Phase 1 for `nix-darwin` support while preserving existing `chezmoi`/Homebrew/mise setup.
- Provide a flake-based entrypoint and a simple darwin module to enable gradual adoption on both Apple Silicon and Intel macs.
- Document setup and basic usage in `README.md` to guide macOS contributors through initial installation steps.

### Description
- Added `macos/nix/flake.nix` which defines `nix-darwin` as an input and provides `darwinConfigurations` for `dotfiles` (aarch64) and `dotfiles-intel` (x86_64). 
- Added `macos/nix/darwin/default.nix` as a minimal nix-darwin module that sets `system.stateVersion`, keeps `nix.enable = false` for Determinate installer users, enables flake-related experimental features, installs `git`, and enables `touchIdAuth` for `sudo`.
- Updated `README.md` with a new "nix-darwin (Phase 1)" section including setup steps, example `darwin-rebuild` commands, and a note to adjust `darwinConfigurations` hostnames as needed.
- Added `tests/files/nix-darwin.bats` which contains Bats tests that validate the presence of the flake and module files and assert key configuration snippets in those files.

### Testing
- Ran the new Bats test suite with `bats tests/files/nix-darwin.bats` and all tests passed.
- The tests verify file existence and essential content such as the `nix-darwin` input, `darwinConfigurations`, `system.stateVersion`, and `nix.enable = false`.
- No changes were made to existing CI; the new tests are self-contained and exercise only the added files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38cc2f4f8832d9d8d67c9134acaf9)

## Summary by Sourcery

Introduce an initial nix-darwin configuration for macOS alongside documentation and tests to support gradual adoption without disrupting the existing setup.

New Features:
- Add a nix flake entrypoint for nix-darwin with darwinConfigurations for Apple Silicon and Intel macOS hosts.
- Provide a minimal nix-darwin module configuring core system settings, experimental Nix features, and basic tooling for macOS.

Documentation:
- Document Phase 1 nix-darwin setup and usage instructions in the README, including installation and darwin-rebuild examples for different Mac architectures.

Tests:
- Add Bats tests to verify the presence and key configuration aspects of the nix-darwin flake and module files.