### PR TITLE
chore: Homebrew管理対象からPythonとgo-swaggerを削除

### DIFF
--- a/install/macos/02-brew-packages.bats
+++ b/install/macos/02-brew-packages.bats
@@ -189,7 +189,7 @@ EOF
 }
 
 @test "brew packages skips installed formula and installs missing formula" {
-  write_brew_stub $'bash\nmise\npython@3.12' $'1password\ngoogle-chrome'
+  write_brew_stub $'bash\nmise' $'1password\ngoogle-chrome'
   write_mas_stub ""
 
   run env PATH="$TEST_BIN_DIR:$PATH" bash "$SCRIPT_PATH"
@@ -199,7 +199,7 @@ EOF
 }
 
 @test "brew packages skips installed cask and installs missing cask" {
-  write_brew_stub $'bash\nmise\npython@3.12\ntree' $'1password\ngoogle-chrome'
+  write_brew_stub $'bash\nmise\ntree' $'1password\ngoogle-chrome'
   write_mas_stub ""
 
   run env PATH="$TEST_BIN_DIR:$PATH" bash "$SCRIPT_PATH"
@@ -209,7 +209,7 @@ EOF
 }
 
 @test "brew packages installs mas formula when mas is missing from installed formulae" {
-  write_brew_stub $'bash\nmise\npython@3.12\ntree' $'1password\ngoogle-chrome'
+  write_brew_stub $'bash\nmise\ntree' $'1password\ngoogle-chrome'
   write_mas_stub ""
 
   run env PATH="$TEST_BIN_DIR:$PATH" bash "$SCRIPT_PATH"
@@ -218,7 +218,7 @@ EOF
 }
 
 @test "brew packages skips installed mas app and installs missing mas app" {
-  write_brew_stub $'bash\nmise\npython@3.12\ntree\nmas' $'1password\ngoogle-chrome'
+  write_brew_stub $'bash\nmise\ntree\nmas' $'1password\ngoogle-chrome'
   write_mas_stub $'1429033973 RunCat (3.9)'
 
   run env PATH="$TEST_BIN_DIR:$PATH" bash "$SCRIPT_PATH"
@@ -227,7 +227,7 @@ EOF
 }
 
 @test "brew packages falls back to mas install when mas get fails" {
-  write_brew_stub $'bash\nmise\npython@3.12\ntree\nmas' $'1password\ngoogle-chrome'
+  write_brew_stub $'bash\nmise\ntree\nmas' $'1password\ngoogle-chrome'
   write_mas_stub "" "get_fail"
 
   run env PATH="$TEST_BIN_DIR:$PATH" bash "$SCRIPT_PATH"
@@ -251,7 +251,6 @@ if [ "\$1" = "list" ] && [ "\$2" = "--formula" ]; then
   cat <<'FORMULAE'
 bash
 mise
-python@3.12
 FORMULAE
   exit 0
 fi

--- a/install/macos/02-brew-packages.sh
+++ b/install/macos/02-brew-packages.sh
@@ -112,14 +112,12 @@ function install_packages() {
   local taps=(
     "aws/tap"
     "dotenvx/brew"
-    "go-swagger/go-swagger"
   )
 
   local formulae=(
     "bash"
     "mas"
     "mise"
-    "python@3.12"
     "tree"
   )
 

--- a/install/macos/Brewfile
+++ b/install/macos/Brewfile
@@ -1,15 +1,12 @@
 # Taps
 tap "aws/tap"
 tap "dotenvx/brew"
-tap "go-swagger/go-swagger"
 
 # Formulae (explicitly installed)
 # Bourne-Again SHell, a UNIX command interpreter
 brew "bash"
 # Polyglot runtime manager (asdf rust clone)
 brew "mise"
-# Interpreted, interactive, object-oriented programming language
-brew "python@3.12"
 # Display directories as trees (with optional color/HTML output)
 brew "tree"
 

--- a/install/macos/private/Brewfile
+++ b/install/macos/private/Brewfile
@@ -1,7 +1,6 @@
 # Taps
 tap "aws/tap"
 tap "dotenvx/brew"
-tap "go-swagger/go-swagger"
 tap "stuartleeks/tap"
 
 # Formulae (explicitly installed)
@@ -29,8 +28,6 @@ brew "librist"
 brew "mas"
 # Polyglot runtime manager (asdf rust clone)
 brew "mise"
-# Interpreted, interactive, object-oriented programming language
-brew "python@3.12"
 # Tools for and transforming and inspecting PDF files
 brew "qpdf"
 # Low-level access to audio, keyboard, mouse, joystick, and graphics


### PR DESCRIPTION
## Description

Homebrew の共通インストール対象から `python@3.12` と `go-swagger/go-swagger` tap を削除します。
Python は mise 側で管理する前提に寄せ、不要になった tap/formula が新規セットアップ時に入らないようにします。

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Related Issues

なし

## Changes Made

- `install/macos/02-brew-packages.sh` から `go-swagger/go-swagger` tap と `python@3.12` formula を削除
- `install/macos/Brewfile` と `install/macos/private/Brewfile` から同じ tap/formula を削除
- `install/macos/02-brew-packages.bats` の Homebrew スタブから `python@3.12` を削除

## Testing

- [x] テストを追加/更新しました
- [ ] 既存のテストがすべて通過します
- [x] 手動で動作確認しました

確認内容:
- `git diff --check`
- `bash -n install/macos/02-brew-packages.sh`
- `rg "go-swagger|python@3\\.12" .` で該当なし
- ローカル Homebrew から `python@3.12` が削除済みであることを確認
- ローカル Homebrew tap から `go-swagger/go-swagger` が削除済みであることを確認

未実施:
- `bats install/macos/02-brew-packages.bats` はローカル環境に `bats` が入っていないため未実行

## Checklist

- [x] コードはプロジェクトのスタイルガイドに従っています
- [x] 自己レビューを実施しました
- [x] コメントを適切に追加しました（特に複雑な部分）
- [x] 関連するドキュメントを更新しました
- [x] 変更によって新しい警告は発生していません
- [x] テストを追加/更新しました
- [ ] すべてのテストが通過します

## Screenshots (if applicable)

なし

## Additional Notes

`python@3.12` のアンインストール時に Homebrew から `openssl@3` と `ca-certificates` の設定ファイルが残っている警告が出ましたが、この PR では設定ファイル削除は扱っていません。

## Summary by Sourcery

Remove Python and go-swagger from the shared Homebrew-managed macOS setup.

Enhancements:
- Update macOS Homebrew install script and Brewfiles to stop managing python@3.12 and the go-swagger/go-swagger tap in favor of external management.
- Adjust Homebrew-related tests to reflect the reduced set of managed formulae.